### PR TITLE
i/o polish

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,8 +21,9 @@
     "url": "git://github.com/PolymerElements/iron-overlay-behavior.git"
   },
   "dependencies": {
+    "polymer": "Polymer/polymer#^0.9.0",
     "iron-fit-behavior": "PolymerElements/iron-fit-behavior#^0.9.0",
-    "polymer": "Polymer/polymer#^0.9.0"
+    "iron-resizable-behavior": "PolymerElements/iron-resizable-behavior#^0.9.0"
   },
   "devDependencies": {
     "iron-component-page": "PolymerElements/iron-component-page#^0.9.0",

--- a/iron-overlay-backdrop.html
+++ b/iron-overlay-backdrop.html
@@ -9,11 +9,22 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 -->
 
 <link rel="import" href="../polymer/polymer.html">
-
 <link rel="import" href="iron-overlay-manager.html">
 
 <!--
-`iron-overlay-backdrop` is a backdrop used by `iron-overlay-behavior`. It should be a singleton.
+`iron-overlay-backdrop` is a backdrop used by `Polymer.IronOverlayBehavior`. It should be a
+singleton.
+
+### Styling
+
+The following custom properties and mixins are available for styling.
+
+Custom property | Description | Default
+-------------------------------------------|------------------------|---------
+`--iron-overlay-backdrop-background-color` | Backdrop background color                                     | #000
+`--iron-overlay-backdrop-opacity`          | Backdrop opacity                                              | 0.6
+`--iron-overlay-backdrop`                  | Mixin applied to `iron-overlay-backdrop`.                      | {}
+`--iron-overlay-backdrop-opened`           | Mixin applied to `iron-overlay-backdrop` when it is displayed | {}
 -->
 
 <dom-module id="iron-overlay-backdrop">
@@ -34,7 +45,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     }
 
     :host([opened]) {
-      opacity: 0.6;
+      opacity: var(--iron-overlay-backdrop-opacity, 0.6);
 
       @apply(--iron-overlay-backdrop-opened);
     }
@@ -75,7 +86,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     },
 
     /**
-     * Appends the backdrop to document body and sets its z-index to be below the latest overlay.
+     * Appends the backdrop to document body and sets its `z-index` to be below the latest overlay.
      */
     prepare: function() {
       if (!this.parentNode) {

--- a/iron-overlay-behavior.html
+++ b/iron-overlay-behavior.html
@@ -10,44 +10,52 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../iron-fit-behavior/iron-fit-behavior.html">
-
+<link rel="import" href="../iron-resizable-behavior/iron-resizable-behavior.html">
 <link rel="import" href="iron-overlay-backdrop.html">
 <link rel="import" href="iron-overlay-manager.html">
 
-<!--
-`iron-overlay-behavior` displays an element on top of other content. It starts out hidden and is
-displayed by calling `open()` or setting the `opened` property to `true`. It may be closed by
-calling `close()` or `cancel()`, or by setting the `opened` property to `true`.
-
-The difference between `close()` and `cancel()` is user intent. `close()` generally implies that
-the user acknowledged the content of the overlay. By default, it will cancel whenever the user taps
-outside it or presses the escape key. This behavior can be turned off via the `no-cancel-on-esc-key`
-and the `no-cancel-on-outside-click` properties.
--->
-
-<!--
-Fired after the `iron-overlay` opens.
-@event iron-overlay-opened
--->
-
-<!--
-Fired after the `iron-overlay` closes.
-@event iron-overlay-closed
-@param {Object} detail
-@param {Object} detail.canceled True if the overlay was canceled
--->
-
 <script>
 
-  /** @polymerBehavior */
-  Polymer.IronOverlayBehavior = [Polymer.IronFitBehavior, {
+/*
+Use `Polymer.IronOverlayBehavior` to implement an element that can be hidden or shown, and displays
+on top of other content. It includes an optional backdrop, and can be used to implement a variety
+of UI controls including dialogs and drop downs. Multiple overlays may be displayed at once.
+
+### Closing and canceling
+
+A dialog may be hidden by closing or canceling. The difference between close and cancel is user
+intent. Closing generally implies that the user acknowledged the content on the overlay. By default,
+it will cancel whenever the user taps outside it or presses the escape key. This behavior is
+configurable with the `no-cancel-on-esc-key` and the `no-cancel-on-outside-click` properties.
+`close()` should be called explicitly by the implementer when the user interacts with a control
+in the overlay element.
+
+### Positioning
+
+By default the element is sized and positioned to fit and centered inside the window. You can
+position and size it manually using CSS. See `Polymer.IronFitBehavior`.
+
+### Backdrop
+
+Set the `with-backdrop` attribute to display a backdrop behind the overlay. The backdrop is
+appended to `<body>` and is of type `<iron-overlay-backdrop>`. See its doc page for styling
+options.
+
+### Limitations
+
+The element is styled to appear on top of other content by setting its `z-index` property. You
+must ensure no element has a stacking context with a higher `z-index` than its parent stacking
+context. You should place this element as a child of `<body>` whenever possible.
+
+@polymerBehavior Polymer.IronOverlayBehavior
+*/
+
+  Polymer.IronOverlayBehaviorImpl = {
 
     properties: {
 
       /**
-       * Set opened to true to show an overlay and to false to hide it.
-       * A `iron-overlay` may be made initially opened by setting its
-       * `opened` attribute.
+       * True if the overlay is currently displayed.
        */
       opened: {
         observer: '_openedChanged',
@@ -56,7 +64,7 @@ Fired after the `iron-overlay` closes.
       },
 
       /**
-       * True if the overlay was cancelled.
+       * True if the overlay was canceled when it was last closed.
        */
       canceled: {
         observer: '_canceledChanged',
@@ -66,10 +74,7 @@ Fired after the `iron-overlay` closes.
       },
 
       /**
-       * If true, the overlay has a backdrop darkening the rest of the screen.
-       * The backdrop element is attached to the document body and may be styled
-       * with the class `iron-overlay-backdrop`. When opened the `iron-opened`
-       * class is applied.
+       * Set to true to display a backdrop behind the overlay.
        */
       withBackdrop: {
         type: Boolean,
@@ -127,21 +132,19 @@ Fired after the `iron-overlay` closes.
         value: function() {
           return this._onCaptureKeydown.bind(this);
         }
-      },
-
-      _boundOnResize: {
-        type: Function,
-        value: function() {
-          return this._onResize.bind(this);
-        }
       }
 
     },
 
     listeners: {
-      'click': '_onClick'
+      'click': '_onClick',
+      'iron-resize': '_onIronResize'
     },
 
+    /**
+     * The backdrop element.
+     * @type Node
+     */
     get backdropElement() {
       return this._backdrop;
     },
@@ -208,6 +211,12 @@ Fired after the `iron-overlay` closes.
     },
 
     _openedChanged: function() {
+      if (this.opened) {
+        this.removeAttribute('aria-hidden');
+      } else {
+        this.setAttribute('aria-hidden', 'true');
+      }
+
       // wait to call after ready only if we're initially open
       if (!this._overlaySetup) {
         this._callOpenedWhenReady = this.opened;
@@ -216,8 +225,6 @@ Fired after the `iron-overlay` closes.
       if (this._openChangedAsync) {
         this.cancelAsync(this._openChangedAsync);
       }
-
-      this._transitioning = true;
 
       this._toggleListeners();
 
@@ -264,7 +271,6 @@ Fired after the `iron-overlay` closes.
         this._toggleListener(this.opened, document, 'keydown', this._boundOnCaptureKeydown, true);
         this._toggleListenersAsync = null;
       });
-      this._toggleListener(this.opened, window, 'resize', this._boundOnResize, false);
     },
 
     // tasks which must occur before opening; e.g. making the element visible
@@ -284,17 +290,9 @@ Fired after the `iron-overlay` closes.
     // tasks which cause the overlay to actually open; typically play an
     // animation
     _renderOpened: function() {
-      // this.notifyResize();
       if (this.withBackdrop) {
         this.backdropElement.open();
       }
-      // FIXME implement transitions
-      // var transition = this.getTransition();
-      // if (transition) {
-      //   transition.go(this, {opened: this.opened});
-      // } else {
-        // this.transitionend();
-      // }
       this._finishRenderOpened();
     },
 
@@ -310,7 +308,6 @@ Fired after the `iron-overlay` closes.
       if (event && event.target !== this) {
         return;
       }
-      this._transitioning = false;
       if (this.opened) {
         this._finishRenderOpened();
       } else {
@@ -325,6 +322,8 @@ Fired after the `iron-overlay` closes.
       }
 
       this.fire('iron-overlay-opened');
+
+      this.async(this.notifyResize);
     },
 
     _finishRenderClosed: function() {
@@ -339,6 +338,8 @@ Fired after the `iron-overlay` closes.
       this._manager.focusOverlay();
 
       this.fire('iron-overlay-closed', this.closingReason);
+
+      this.async(this.notifyResize);
     },
 
     _completeBackdrop: function() {
@@ -362,7 +363,7 @@ Fired after the `iron-overlay` closes.
       this.style.transition = this.style.webkitTransition = '';
     },
 
-    applyFocus: function() {
+    _applyFocus: function() {
       if (this.opened) {
         if (!this.noAutoFocus) {
           this._focusNode.focus();
@@ -373,14 +374,10 @@ Fired after the `iron-overlay` closes.
       }
     },
 
-    // We use the traditional approach of capturing events on document
-    // to to determine if the overlay needs to close. However, due to
-    // ShadowDOM event retargeting, the event target is not useful. Instead
-    // of using it, we attempt to close asynchronously and prevent the close
-    // if a tap event is immediately heard on the target.
-    // TODO(sorvell): This approach will not work with modal. For
-    // this we need a scrim.
     _onCaptureClick: function(event) {
+      // attempt to close asynchronously and prevent the close of a tap event is immediately heard
+      // on target. This is because in shadow dom due to event retargetting event.target is not
+      // useful.
       if (!this.noCancelOnOutsideClick && (this._manager.currentOverlay() == this)) {
         this._cancelJob = this.async(function() {
           this.cancel();
@@ -403,10 +400,24 @@ Fired after the `iron-overlay` closes.
       }
     },
 
-    _onResize: function() {
+    _onIronResize: function() {
       this.refit();
     }
 
-  }];
+  };
+
+  Polymer.IronOverlayBehavior = [Polymer.IronFitBehavior, Polymer.IronResizableBehavior, Polymer.IronOverlayBehaviorImpl];
+
+/*
+Fired after the `iron-overlay` opens.
+@event iron-overlay-opened
+*/
+
+/*
+Fired after the `iron-overlay` closes.
+@event iron-overlay-closed
+@param {Object} detail
+@param {Object} detail.canceled True if the overlay was canceled
+*/
 
 </script>

--- a/iron-overlay-manager.html
+++ b/iron-overlay-manager.html
@@ -69,9 +69,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       //
       // NOTE: We make the assumption that any overlay that completes a transition
       // will call into focusOverlay to kick the process back off. Currently:
-      // transitionend -> applyFocus -> focusOverlay.
+      // transitionend -> _applyFocus -> focusOverlay.
       if (current && !current.transitioning) {
-        current.applyFocus();
+        current._applyFocus();
       }
     }
 

--- a/test/iron-overlay-behavior.html
+++ b/test/iron-overlay-behavior.html
@@ -254,7 +254,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         test('backdrop is removed when the element is removed from DOM', function(done) {
           runAfterOpen(overlays[0], function() {
             var backdrop = overlays[0].backdropElement;
-            overlays[0].remove();
+            Polymer.dom(backdrop.parentNode).removeChild(backdrop);
+            Polymer.dom.flush();
             assert.isNull(backdrop.parentNode, 'backdrop is removed from DOM');
             done();
           });
@@ -293,6 +294,19 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
 
       });
+
+      suite('a11y', function() {
+
+        test('overlay has aria-hidden=true when opened', function() {
+          var overlay = fixture('basic');
+          assert.equal(overlay.getAttribute('aria-hidden'), 'true', 'overlay has aria-hidden="true"');
+          overlay.open();
+          assert.isFalse(overlay.hasAttribute('aria-hidden'), 'overlay does not have aria-hidden attribute');
+          overlay.close();
+          assert.equal(overlay.getAttribute('aria-hidden'), 'true', 'overlay has aria-hidden="true"');
+        });
+
+      })
 
     </script>
 


### PR DESCRIPTION
write docs, add aria-hidden, use iron-resizable, fix tests

PTAL @cdata cc @notwaldorf 

I documented the styling properties in `<iron-overlay-backdrop>` with a table. WDYT about adding docs in that style for elements that uses custom properties?