### PR TITLE
Update iron-overlay-behavior.html

### DIFF
--- a/iron-overlay-behavior.html
+++ b/iron-overlay-behavior.html
@@ -421,6 +421,7 @@ context. You should place this element as a child of `<body>` whenever possible.
         return;
       }
       if (this.opened) {
+        this.resetFit();
         this.refit();
       }
     }


### PR DESCRIPTION
Added "this.resetFit();" to "_onIronResize" function, I made this change on my projects and it fixes the problem where "paper-dialog" doesn't stay centralised when the window is resized.