### PR TITLE
Current overlay is always the latest `opened` one

### DIFF
--- a/iron-overlay-manager.html
+++ b/iron-overlay-manager.html
@@ -45,7 +45,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     }
 
     function currentOverlay() {
-      return overlays[overlays.length-1];
+      var i = overlays.length - 1;
+      while (overlays[i] && !overlays[i].opened) {
+        --i;
+      }
+      return overlays[i];
     }
 
     function currentOverlayZ() {

--- a/test/iron-overlay-behavior.html
+++ b/test/iron-overlay-behavior.html
@@ -141,6 +141,24 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           });
         });
 
+        test('close an overlay in proximity to another overlay', function(done) {
+          var secondOverlay = fixture('basic');
+          // Open and close a separate overlay.
+          secondOverlay.open();
+          secondOverlay.close();
+
+          // Open the overlay we care about.
+          overlay.open();
+
+          // Wait for infinite recursion, otherwise we win:
+          overlay.addEventListener('iron-overlay-closed', function() {
+            done();
+          });
+
+          // Immediately close the first overlay:
+          overlay.close();
+        });
+
         test('clicking an overlay does not close it', function(done) {
           runAfterOpen(overlay, function() {
             overlay.addEventListener('iron-overlay-closed', function() {


### PR DESCRIPTION
This distinction prevents a sequence of unending execution due to
separate overlays opening and closing in close proximity to each other.

Fixes #31