### PR TITLE
Fix #21, iOS backdrop does not close

### DIFF
--- a/iron-overlay-behavior.html
+++ b/iron-overlay-behavior.html
@@ -269,6 +269,7 @@ context. You should place this element as a child of `<body>` whenever possible.
       }
       // async so we don't auto-close immediately via a click.
       this._toggleListenersAsync = this.async(function() {
+        this._toggleListener(this.opened, document, 'touchstart', this._boundOnCaptureClick, true);
         this._toggleListener(this.opened, document, 'click', this._boundOnCaptureClick, true);
         this._toggleListener(this.opened, document, 'keydown', this._boundOnCaptureKeydown, true);
         this._toggleListenersAsync = null;


### PR DESCRIPTION
See #21 on iOS Safari, overlay does not close when clicking on backdrop
Cause:
- iron-overlay closes by listening to `click` on document.
- on iOS, `click` does not bubble, and never gets triggered (see http://www.quirksmode.org/blog/archives/2014/02/mouse_event_bub.html)

My quick fix is to add a `touchstart` listener. I've tested it, and it works for me. 