### PR TITLE
Adds 'iron-overlay-canceled' event, calling `preventDefault` prevents…

### DIFF
--- a/iron-overlay-behavior.html
+++ b/iron-overlay-behavior.html
@@ -28,7 +28,8 @@ intent. Closing generally implies that the user acknowledged the content on the 
 it will cancel whenever the user taps outside it or presses the escape key. This behavior is
 configurable with the `no-cancel-on-esc-key` and the `no-cancel-on-outside-click` properties.
 `close()` should be called explicitly by the implementer when the user interacts with a control
-in the overlay element.
+in the overlay element. When the dialog is canceled, the overlay fires an 'iron-overlay-canceled'
+event. Call `preventDefault` on this event to prevent the overlay from closing.
 
 ### Positioning
 
@@ -199,6 +200,11 @@ context. You should place this element as a child of `<body>` whenever possible.
      * Cancels the overlay.
      */
     cancel: function() {
+      var cancelEvent = this.fire('iron-overlay-canceled', undefined, {cancelable: true});
+      if (cancelEvent.defaultPrevented) {
+        return;
+      }
+
       this.opened = false;
       this._setCanceled(true);
     },

--- a/test/iron-overlay-behavior.html
+++ b/test/iron-overlay-behavior.html
@@ -181,6 +181,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         test('cancel an overlay by clicking outside', function(done) {
           runAfterOpen(overlay, function() {
+            overlay.addEventListener('iron-overlay-canceled', function(event) {
+              done();
+            });
+            Polymer.Base.fire.call(document, 'click');
+          });
+        });
+
+        test('close an overlay by clicking outside', function(done) {
+          runAfterOpen(overlay, function() {
             overlay.addEventListener('iron-overlay-closed', function(event) {
               assert.isTrue(event.detail.canceled, 'overlay is canceled');
               done();
@@ -189,7 +198,35 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           });
         });
 
+        test('cancel event can be prevented', function(done) {
+          runAfterOpen(overlay, function() {
+            overlay.addEventListener('iron-overlay-canceled', function(event) {
+              event.preventDefault();
+            });
+            var closedListener = function(event) {
+              throw new Error('iron-overlay-closed should not fire');
+            };
+            overlay.addEventListener('iron-overlay-closed', closedListener);
+            Polymer.Base.fire.call(document, 'click');
+            setTimeout(function() {
+              overlay.removeEventListener('iron-overlay-closed', closedListener);
+              done();
+            }, 10);
+          });
+        });
+
         test('cancel an overlay with esc key', function(done) {
+          runAfterOpen(overlay, function() {
+            overlay.addEventListener('iron-overlay-canceled', function(event) {
+              done();
+            });
+            fireEvent('keydown', {
+              keyCode: 27
+            }, document);
+          });
+        });
+
+        test('close an overlay with esc key', function(done) {
           runAfterOpen(overlay, function() {
             overlay.addEventListener('iron-overlay-closed', function(event) {
               assert.isTrue(event.detail.canceled, 'overlay is canceled');


### PR DESCRIPTION
… the overlay from closing. (Fix for #37.)