### PR TITLE
stop bringing in the paper-styles kitchen sink

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -29,7 +29,7 @@
     "iron-flex-layout": "PolymerElements/iron-flex-layout#^1.0.0",
     "iron-test-helpers": "PolymerElements/iron-test-helpers#^1.0.0",
     "test-fixture": "PolymerElements/test-fixture#^1.0.0",
-    "web-component-tester": "*",
+    "web-component-tester": "polymer/web-component-tester#^3.4.0",
     "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0"
   },
   "ignore": []

--- a/demo/index.html
+++ b/demo/index.html
@@ -19,14 +19,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
 
-    <link rel="import" href="../../iron-flex-layout/classes/iron-flex-layout.html">
-    <!-- <link rel="import" href="../core-transition/core-transition-css.html"> -->
+    <link rel="import" href="../../iron-flex-layout/iron-flex-layout.html">
     <link rel="import" href="simple-overlay.html">
-
-    <link rel="import" href="../../paper-styles/paper-styles.html">
     <link rel="import" href="../../paper-styles/demo-pages.html">
 
-    <style>
+    <style is="custom-style">
 
       .with-margin {
         margin: 24px 40px;
@@ -40,6 +37,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         overflow: auto;
       }
 
+      .vertical {
+        @apply(--layout-vertical);
+      }
+
+      .flex {
+        @apply(--layout-flex);
+      }
     </style>
 
   </head>
@@ -78,7 +82,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       <button data-dialog="scrolling-2">scrolling 2</button>
 
-      <simple-overlay id="scrolling-2" class="with-margin full-height layout vertical">
+      <simple-overlay id="scrolling-2" class="with-margin full-height vertical">
         <p>This dialog has a scrolling child.</p>
         <div class="flex scrollable">
           <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>

--- a/demo/simple-overlay.html
+++ b/demo/simple-overlay.html
@@ -9,7 +9,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 -->
 
 <link rel="import" href="../../polymer/polymer.html">
-
 <link rel="import" href="../iron-overlay-behavior.html">
 
 <dom-module id="simple-overlay">

--- a/test/iron-overlay-behavior.html
+++ b/test/iron-overlay-behavior.html
@@ -20,10 +20,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
 
     <script src="../../web-component-tester/browser.js"></script>
-    <script src="../../test-fixture/test-fixture-mocha.js"></script>
     <script src="../../iron-test-helpers/test-helpers.js"></script>
-
-    <link rel="import" href="../../test-fixture/test-fixture.html">
     <link rel="import" href="test-overlay.html">
 
   </head>


### PR DESCRIPTION
Fixes the generic usage of `paper-styles.html` and `/deep/` classes and uses the specific imports instead. Also updates the test to the new `wct#^3.4.0` way