### PR TITLE
Compute position on attached

### DIFF
--- a/iron-overlay-behavior.html
+++ b/iron-overlay-behavior.html
@@ -162,6 +162,10 @@ context. You should place this element as a child of `<body>` whenever possible.
 
     ready: function() {
       this._ensureSetup();
+    },
+
+    attached: function() {
+      // Call _openedChanged here so that position can be computed correctly.
       if (this._callOpenedWhenReady) {
         this._openedChanged();
       }

--- a/test/iron-overlay-behavior.html
+++ b/test/iron-overlay-behavior.html
@@ -20,7 +20,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
 
     <script src="../../web-component-tester/browser.js"></script>
-    <script src="../../iron-test-helpers/test-helpers.js"></script>
+    <link rel="import" href="../../iron-test-helpers/iron-test-helpers.html">
     <link rel="import" href="test-overlay.html">
 
   </head>
@@ -100,11 +100,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           assert.equal(getComputedStyle(overlay).display, 'none', 'overlay starts hidden');
         });
 
-        test('overlay open by default', function() {
+        test('overlay open by default', function(done) {
           overlay = fixture('opened');
           runAfterOpen(overlay, function() {
             assert.isTrue(overlay.opened, 'overlay starts opened');
             assert.notEqual(getComputedStyle(overlay).display, 'none', 'overlay starts showing');
+            done();
           });
         });
 
@@ -181,7 +182,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             overlay.addEventListener('iron-overlay-canceled', function(event) {
               done();
             });
-            Polymer.Base.fire.call(document, 'click');
+            MockInteractions.tap(document.body);
           });
         });
 
@@ -191,7 +192,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
               assert.isTrue(event.detail.canceled, 'overlay is canceled');
               done();
             });
-            Polymer.Base.fire.call(document, 'click');
+            MockInteractions.tap(document.body);
           });
         });
 
@@ -204,7 +205,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
               throw new Error('iron-overlay-closed should not fire');
             };
             overlay.addEventListener('iron-overlay-closed', closedListener);
-            Polymer.Base.fire.call(document, 'click');
+            MockInteractions.tap(document.body);
             setTimeout(function() {
               overlay.removeEventListener('iron-overlay-closed', closedListener);
               done();
@@ -241,7 +242,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             overlay.addEventListener('iron-overlay-closed', function() {
               assert('iron-overlay-closed should not fire');
             });
-            Polymer.Base.fire.call(document, 'click');
+            MockInteractions.tap(document.body);
             setTimeout(function() {
               done();
             }, 10);

--- a/test/iron-overlay-behavior.html
+++ b/test/iron-overlay-behavior.html
@@ -102,9 +102,19 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         test('overlay open by default', function(done) {
           overlay = fixture('opened');
-          runAfterOpen(overlay, function() {
+          overlay.addEventListener('iron-overlay-opened', function() {
             assert.isTrue(overlay.opened, 'overlay starts opened');
             assert.notEqual(getComputedStyle(overlay).display, 'none', 'overlay starts showing');
+            done();
+          });
+        });
+
+        test('overlay positioned & sized properly', function(done) {
+          overlay = fixture('opened');
+          overlay.addEventListener('iron-overlay-opened', function() {
+            var s = getComputedStyle(overlay);
+            assert.isTrue(parseFloat(s.left) === (window.innerWidth - overlay.offsetWidth)/2, 'centered horizontally');
+            assert.isTrue(parseFloat(s.top) === (window.innerHeight - overlay.offsetHeight)/2, 'centered vertically');
             done();
           });
         });


### PR DESCRIPTION
Fixes #60 by waiting for element to be attached to call `this._openChanged`. Only on attached we can safely compute the element's position.
Fixes #57 by using `MockInteractions.tap` :balloon: 