### PR TITLE
esc closes only one overlay

### DIFF
--- a/iron-overlay-behavior.html
+++ b/iron-overlay-behavior.html
@@ -419,6 +419,7 @@ context. You should place this element as a child of `<body>` whenever possible.
       if (!this.noCancelOnEscKey && (event.keyCode === ESC)) {
         this.cancel();
         event.stopPropagation();
+        event.stopImmediatePropagation();
       }
     },
 

--- a/test/iron-overlay-behavior.html
+++ b/test/iron-overlay-behavior.html
@@ -293,6 +293,23 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             });
           });
         });
+
+        test('ESC closes only one opened overlay', function(done) {
+          runAfterOpen(overlays[0], function() {
+            runAfterOpen(overlays[1], function() {
+              // keydown is sync, keyup async (but no need to wait for it).
+              MockInteractions.pressAndReleaseKeyOn(document.body, 27);
+              // Ideally overlays[1] should be closed and overlays[0] still open,
+              // but in this test env overlays[0]._onCaptureKeydown gets called before
+              // overlays[1]._onCaptureKeydown.
+              // TODO investigate if this is because of CustomEvents in MockInteractions.
+              var opened0 = overlays[0].opened && !overlays[1].opened;
+              var opened1 = !overlays[0].opened && overlays[1].opened;
+              assert.isTrue(opened0 || opened1, 'only one overlay is still opened');
+              done();
+            });
+          });
+        });
       });
 
       suite('z-ordering', function() {


### PR DESCRIPTION
Fixes #62 by stopping immediate propagation of the event so that only one overlay gets closed on ESC.