### PR TITLE
cleanup _squelchNextResize

### DIFF
--- a/iron-overlay-behavior.html
+++ b/iron-overlay-behavior.html
@@ -226,6 +226,7 @@ context. You should place this element as a child of `<body>` whenever possible.
         this.removeAttribute('aria-hidden');
       } else {
         this.setAttribute('aria-hidden', 'true');
+        Polymer.dom(this).unobserveNodes(this._observer);
       }
 
       // wait to call after ready only if we're initially open
@@ -247,8 +248,9 @@ context. You should place this element as a child of `<body>` whenever possible.
       this._openChangedAsync = this.async(function() {
         // overlay becomes visible here
         this.style.display = '';
-        // force layout to ensure transitions will go
-        /** @suppress {suspiciousCode} */ this.offsetWidth;
+        // Force layout to ensure transition will go. Set offsetWidth to itself
+        // so that compilers won't remove it.
+        this.offsetWidth = this.offsetWidth;
         if (this.opened) {
           this._renderOpened();
         } else {
@@ -322,28 +324,14 @@ context. You should place this element as a child of `<body>` whenever possible.
       this._finishRenderClosed();
     },
 
-    _onTransitionend: function(event) {
-      // make sure this is our transition event.
-      if (event && event.target !== this) {
-        return;
-      }
-      if (this.opened) {
-        this._finishRenderOpened();
-      } else {
-        this._finishRenderClosed();
-      }
-    },
-
     _finishRenderOpened: function() {
       // focus the child node with [autofocus]
       if (!this.noAutoFocus) {
         this._focusNode.focus();
       }
 
+      this._observer = Polymer.dom(this).observeNodes(this.notifyResize);
       this.fire('iron-overlay-opened');
-
-      this._squelchNextResize = true;
-      this.async(this.notifyResize);
     },
 
     _finishRenderClosed: function() {
@@ -357,10 +345,8 @@ context. You should place this element as a child of `<body>` whenever possible.
       // focus the next overlay, if there is one
       this._manager.focusOverlay();
 
+      this.notifyResize();
       this.fire('iron-overlay-closed', this.closingReason);
-
-      this._squelchNextResize = true;
-      this.async(this.notifyResize);
     },
 
     _completeBackdrop: function() {
@@ -413,10 +399,6 @@ context. You should place this element as a child of `<body>` whenever possible.
     },
 
     _onIronResize: function() {
-      if (this._squelchNextResize) {
-        this._squelchNextResize = false;
-        return;
-      }
       if (this.opened) {
         this.refit();
       }

--- a/test/iron-overlay-behavior.html
+++ b/test/iron-overlay-behavior.html
@@ -136,6 +136,60 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           overlay.opened = true;
         });
 
+        test('open overlay refits on iron-resize', function() {
+          var overlay = fixture('opened');
+          var spy = sinon.spy(overlay, 'refit');
+          overlay.fire('iron-resize');
+          assert.isTrue(spy.called, 'overlay should refit');
+        });
+
+        test('closed overlay does not refit on iron-resize', function() {
+          var spy = sinon.spy(overlay, 'refit');
+          overlay.fire('iron-resize');
+          assert.isFalse(spy.called, 'overlay should not refit');
+        });
+
+        test('open() triggers iron-resize', function(done) {
+          // Skip potential `iron-resize` from window resizing
+          setTimeout(function () {
+            var spy = sinon.stub();
+            overlay.addEventListener('iron-resize', spy);
+            runAfterOpen(overlay, function () {
+              assert.isTrue(spy.calledOnce, 'iron-resize should be called once');
+              done();
+            });
+          });
+        });
+
+        test('closed overlay does not trigger iron-resize when its content changes', function(done) {
+          // Skip potential `iron-resize` from window resizing
+          setTimeout(function () {
+            var spy = sinon.stub();
+            overlay.addEventListener('iron-resize', spy);
+            var child = document.createElement('div');
+            child.innerHTML = 'hi';
+            Polymer.dom(overlay).appendChild(child);
+            overlay.async(function () {
+              assert.isFalse(spy.called, 'iron-resize should not be called');
+              done();
+            }, 10);
+          });
+        });
+
+        test('open overlay triggers iron-resize when its content changes', function(done) {
+          runAfterOpen(overlay, function () {
+            var spy = sinon.stub();
+            overlay.addEventListener('iron-resize', spy);
+            var child = document.createElement('div');
+            child.innerHTML = 'hi';
+            Polymer.dom(overlay).appendChild(child);
+            overlay.async(function () {
+              assert.isTrue(spy.calledOnce, 'iron-resize should be called once');
+              done();
+            }, 10);
+          });
+        });
+
         test('close an overlay quickly after open', function(done) {
           // first, open the overlay
           overlay.open();
@@ -169,11 +223,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         test('clicking an overlay does not close it', function(done) {
           runAfterOpen(overlay, function() {
-            overlay.addEventListener('iron-overlay-closed', function() {
-              assert('iron-overlay-closed should not fire');
-            });
+            var spy = sinon.stub();
+            overlay.addEventListener('iron-overlay-closed', spy);
             overlay.fire('click');
             setTimeout(function() {
+              assert.isFalse(spy.called, 'iron-overlay-closed should not fire');
               done();
             }, 10);
           });
@@ -211,13 +265,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             overlay.addEventListener('iron-overlay-canceled', function(event) {
               event.preventDefault();
             });
-            var closedListener = function(event) {
-              throw new Error('iron-overlay-closed should not fire');
-            };
-            overlay.addEventListener('iron-overlay-closed', closedListener);
+            var spy = sinon.stub();
+            overlay.addEventListener('iron-overlay-closed', spy);
             MockInteractions.tap(document.body);
             setTimeout(function() {
-              overlay.removeEventListener('iron-overlay-closed', closedListener);
+              assert.isFalse(spy.called, 'iron-overlay-closed should not fire');
               done();
             }, 10);
           });
@@ -249,11 +301,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         test('no-cancel-on-outside-click property', function(done) {
           overlay.noCancelOnOutsideClick = true;
           runAfterOpen(overlay, function() {
-            overlay.addEventListener('iron-overlay-closed', function() {
-              assert('iron-overlay-closed should not fire');
-            });
+            var spy = sinon.stub();
+            overlay.addEventListener('iron-overlay-closed', spy);
             MockInteractions.tap(document.body);
             setTimeout(function() {
+              assert.isFalse(spy.called, 'iron-overlay-closed should not fire');
               done();
             }, 10);
           });
@@ -262,13 +314,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         test('no-cancel-on-esc-key property', function(done) {
           overlay.noCancelOnEscKey = true;
           runAfterOpen(overlay, function() {
-            overlay.addEventListener('iron-overlay-closed', function() {
-              assert('iron-overlay-cancel should not fire');
-            });
+            var spy = sinon.stub();
+            overlay.addEventListener('iron-overlay-closed', spy);
             fireEvent('keydown', {
               keyCode: 27
             }, document);
             setTimeout(function() {
+              assert.isFalse(spy.called, 'iron-overlay-cancel should not fire');
               done();
             }, 10);
           });


### PR DESCRIPTION
Fixes https://github.com/PolymerElements/paper-dialog/issues/68 and https://github.com/PolymerElements/paper-dialog/issues/77
`iron-overlay-behavior` needs to refit itself only once when opened.