### PR TITLE
update backdrop parent to make it sibling of the opened overlay with backdrop

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -120,7 +120,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       <button data-dialog="backdrop">backdrop</button>
 
       <simple-overlay id="backdrop" with-backdrop>
-        Hello world!
+        <p>Hello world!</p>
+        <button data-dialog="backdrop2">backdrop2</button>
+        <simple-overlay id="backdrop2" with-backdrop>
+          backdrop 2
+        </simple-overlay>
       </simple-overlay>
 
       <button data-dialog="autofocus">autofocus</button>

--- a/iron-overlay-backdrop.html
+++ b/iron-overlay-backdrop.html
@@ -86,11 +86,12 @@ Custom property | Description | Default
     },
 
     /**
-     * Appends the backdrop to document body and sets its `z-index` to be below the latest overlay.
+     * Moves the backdrop before sibling and sets its `z-index` to be below the latest overlay.
      */
-    prepare: function() {
-      if (!this.parentNode) {
-        Polymer.dom(document.body).appendChild(this);
+    prepare: function(sibling) {
+      var parent = sibling ? Polymer.dom(sibling).parentNode : document.body;
+      if (this.parentNode !== parent) {
+        Polymer.dom(parent).insertBefore(this, sibling);
         this.style.zIndex = this._manager.currentOverlayZ() - 1;
       }
     },

--- a/iron-overlay-behavior.html
+++ b/iron-overlay-behavior.html
@@ -297,7 +297,7 @@ context. You should place this element as a child of `<body>` whenever possible.
       this._manager.addOverlay(this);
 
       if (this.withBackdrop) {
-        this.backdropElement.prepare();
+        this.backdropElement.prepare(this);
         this._manager.trackBackdrop(this);
       }
 
@@ -357,6 +357,11 @@ context. You should place this element as a child of `<body>` whenever possible.
       // focus the next overlay, if there is one
       this._manager.focusOverlay();
 
+      var curOverlay = this._manager.currentOverlay();
+      // Must move backdropElement to be siblings with this
+      if (curOverlay && curOverlay.opened && this.withBackdrop && curOverlay.withBackdrop) {
+        curOverlay.backdropElement.prepare(curOverlay);
+      }
       this.fire('iron-overlay-closed', this.closingReason);
 
       this._squelchNextResize = true;

--- a/test/iron-overlay-behavior.html
+++ b/test/iron-overlay-behavior.html
@@ -79,6 +79,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       </template>
     </test-fixture>
 
+    <test-fixture id="backdrop-parent">
+      <template>
+        <test-overlay with-backdrop>
+          <test-overlay with-backdrop>
+            Overlay 2
+          </test-overlay>
+        </test-overlay>
+      </template>
+    </test-fixture>
+
     <script>
 
       function runAfterOpen(overlay, cb) {
@@ -419,6 +429,38 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           });
         });
 
+      });
+
+      suite('overlay with backdrop not in <body>', function() {
+        var outerOverlay, innerOverlay;
+
+        setup(function() {
+          outerOverlay = fixture('backdrop-parent');
+          innerOverlay = outerOverlay.children[0];
+        });
+
+        test('innerOverlay and backdrop are siblings', function(done) {
+          innerOverlay.addEventListener('iron-overlay-opened', function() {
+            assert.isTrue(innerOverlay.backdropElement.parentNode === Polymer.dom(innerOverlay).parentNode, 'backdrop and innerOverlay have the same parent');
+            done();
+          });
+          // Open both overlays
+          outerOverlay.open();
+          innerOverlay.open();
+        });
+
+        test('backdrop gets moved to new parent after closing top overlay with backdrop', function(done) {
+          innerOverlay.addEventListener('iron-overlay-opened', function() {
+            innerOverlay.close();
+          });
+          innerOverlay.addEventListener('iron-overlay-closed', function() {
+            assert.isTrue(outerOverlay.backdropElement.parentNode === Polymer.dom(outerOverlay).parentNode, 'backdrop parent got updated');
+            done();
+          });
+          // Open both overlays
+          outerOverlay.open();
+          innerOverlay.open();
+        });
       });
 
       suite('a11y', function() {


### PR DESCRIPTION
Fixes https://github.com/PolymerElements/paper-dialog/issues/44
`iron-overlay-backdrop` now is sibling of the top overlay with backdrop. 
Its `position: fixed` ensures it covers the whole screen and is not cropped. 
Custom styles will be applied if the css selector does not assume `iron-overlay-behavior` is a direct child of `body` :

```css
<style is="custom-style">

  /* will work fine */
  body iron-overlay-backdrop {
    --iron-overlay-backdrop: {
      backdround: red;
  }

  /* will NOT work */
  body > iron-overlay-behavior {
    --iron-overlay-backdrop: {
      background: blue;
  }
</style>