### PR TITLE
Bugfix: backdrop not shared in different elements, causing inconsistent closing

### DIFF
--- a/iron-overlay-behavior.html
+++ b/iron-overlay-behavior.html
@@ -148,15 +148,11 @@ context. You should place this element as a child of `<body>` whenever possible.
      * @type Node
      */
     get backdropElement() {
-      return this._backdrop;
+      return this._manager.backdropElement;
     },
 
     get _focusNode() {
       return Polymer.dom(this).querySelector('[autofocus]') || this;
-    },
-
-    registered: function() {
-      this._backdrop = document.createElement('iron-overlay-backdrop');
     },
 
     ready: function() {

--- a/iron-overlay-manager.html
+++ b/iron-overlay-manager.html
@@ -107,6 +107,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     }
   };
 
+  Object.defineProperty(Polymer.IronOverlayManagerClass.prototype, "backdropElement", {
+    get: function() {
+      if (!this._backdropElement) {
+        this._backdropElement = document.createElement('iron-overlay-backdrop');
+      }
+      return this._backdropElement;
+    }
+  });
+
   Polymer.IronOverlayManagerClass.prototype.getBackdrops = function() {
     return this._backdrops;
   };

--- a/test/iron-overlay-behavior.html
+++ b/test/iron-overlay-behavior.html
@@ -22,6 +22,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <script src="../../web-component-tester/browser.js"></script>
     <link rel="import" href="../../iron-test-helpers/iron-test-helpers.html">
     <link rel="import" href="test-overlay.html">
+    <link rel="import" href="test-overlay2.html">
 
   </head>
   <body>
@@ -76,6 +77,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         <test-overlay with-backdrop class="overlay-3">
           Overlay 3 with backdrop
         </test-overlay>
+      </template>
+    </test-fixture>
+
+    <test-fixture id="backdrop-different-elements">
+      <template>
+        <test-overlay with-backdrop class="overlay-1">
+          Overlay 1 with backdrop
+        </test-overlay>
+        <test-overlay2 with-backdrop class="overlay-2">
+          Overlay 2 with backdrop
+        </test-overlay2>
       </template>
     </test-fixture>
 
@@ -435,6 +447,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             Polymer.dom(backdrop.parentNode).removeChild(backdrop);
             Polymer.dom.flush();
             assert.isNull(backdrop.parentNode, 'backdrop is removed from DOM');
+            assert.lengthOf(document.querySelectorAll('iron-overlay-backdrop'), (0));
             done();
           });
         });
@@ -498,6 +511,44 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
 
       });
+
+      suite('multiple overlays with backdrop implemented in different elements', function () {
+        var overlays;
+
+        setup(function() {
+          overlays = fixture('backdrop-different-elements');
+        });
+
+        test('multiple overlays share the same backdrop', function() {
+          assert.equal(overlays[0].backdropElement, overlays[1].backdropElement);
+        });
+
+        test('when overlays close, the backdrop is closed', function(done) {
+          runAfterOpen(overlays[0], function () {
+            assert.lengthOf(document.querySelectorAll('iron-overlay-backdrop'), 1);
+
+            // After second overlay is closed, both backdrops should be hidden
+            overlays[1].addEventListener('iron-overlay-closed', function() {
+              Polymer.Base.async(function () {
+                assert.isFalse(overlays[1].backdropElement.opened, 'second overlay backdrop is closed');
+                assert.isFalse(overlays[0].backdropElement.opened, 'first overlay backdrop is closed');
+                done();
+              }, 1);
+            });
+            // After second overlay is opened, immediately close it
+            overlays[1].addEventListener('iron-overlay-opened', function() {
+              Polymer.Base.async(function () {
+                overlays[1].close();
+              }, 1);
+            });
+
+            // Immediately close first overlay and open the other one
+            overlays[0].close();
+            overlays[1].open();
+          });
+        });
+
+      })
 
       suite('a11y', function() {
 

--- a/test/test-overlay2.html
+++ b/test/test-overlay2.html
@@ -1,0 +1,49 @@
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+
+<link rel="import" href="../../polymer/polymer.html">
+
+<link rel="import" href="../iron-overlay-behavior.html">
+
+<dom-module id="test-overlay2">
+
+  <style>
+
+    :host {
+      background: white;
+      color: black;
+      border: 1px solid black;
+    }
+
+  </style>
+
+  <template>
+    <content></content>
+  </template>
+
+</dom-module>
+
+<script>
+
+(function() {
+
+  Polymer({
+
+    is: 'test-overlay2',
+
+    behaviors: [
+      Polymer.IronOverlayBehavior
+    ]
+
+  });
+
+})();
+
+</script>


### PR DESCRIPTION
Bug described in #73. This pull request adds the failing tests. 

My approach in #74 is flawed and therefore re-created the tests without the solution. Let's discuss what a reasonable approach to the solution would be. I think that @valdrinkoshi is right, we shouldn't have multiple backdrops, we should only allow one backdrop and that should be managed by the `iron-overlay-manager`.

**EDIT** I've now commited the solution, much more elegant and straightforward: don't allow more than 1 instance of `iron-overlay-backdrop` and let the manager handle the creation of that.