### PR TITLE
update backdrop on with-backdrop changes

### DIFF
--- a/iron-overlay-backdrop.html
+++ b/iron-overlay-backdrop.html
@@ -85,13 +85,18 @@ Custom property | Description | Default
 
     },
 
+    listeners: {
+      'transitionend' : '_onTransitionend'
+    },
+
     /**
      * Appends the backdrop to document body and sets its `z-index` to be below the latest overlay.
      */
     prepare: function() {
+      // Always update z-index
+      this.style.zIndex = this._manager.backdropZ();
       if (!this.parentNode) {
         Polymer.dom(document.body).appendChild(this);
-        this.style.zIndex = this._manager.currentOverlayZ() - 1;
       }
     },
 
@@ -109,9 +114,14 @@ Custom property | Description | Default
      * Hides the backdrop if needed.
      */
     close: function() {
+      // Always update z-index
+      this.style.zIndex = this._manager.backdropZ();
       // only need to make the backdrop invisible if this is called by the last overlay with a backdrop
       if (this._manager.getBackdrops().length < 2) {
         this._setOpened(false);
+        // complete() will be called after the transition is done.
+        // If animations are disabled via custom-styles, user is expected to call
+        // complete() after close()
       }
     },
 
@@ -122,6 +132,12 @@ Custom property | Description | Default
       // only remove the backdrop if there are no more overlays with backdrops
       if (this._manager.getBackdrops().length === 0 && this.parentNode) {
         Polymer.dom(this.parentNode).removeChild(this);
+      }
+    },
+
+    _onTransitionend: function (event) {
+      if (event && event.target === this) {
+        this.complete();
       }
     }
 

--- a/iron-overlay-behavior.html
+++ b/iron-overlay-behavior.html
@@ -80,8 +80,8 @@ context. You should place this element as a child of `<body>` whenever possible.
        * Set to true to display a backdrop behind the overlay.
        */
       withBackdrop: {
-        type: Boolean,
-        value: false
+        observer: '_withBackdropChanged',
+        type: Boolean
       },
 
       /**
@@ -172,7 +172,7 @@ context. You should place this element as a child of `<body>` whenever possible.
 
     detached: function() {
       this.opened = false;
-      this._completeBackdrop();
+      this._manager.trackBackdrop(this);
       this._manager.removeOverlay(this);
     },
 
@@ -266,6 +266,22 @@ context. You should place this element as a child of `<body>` whenever possible.
       this.closingReason.canceled = this.canceled;
     },
 
+    _withBackdropChanged: function() {
+      if (this.opened) {
+        if (this.withBackdrop) {
+          this._manager.trackBackdrop(this);
+          this.backdropElement.prepare();
+          // Give time to be added to document.
+          this.async(function(){
+            this.backdropElement.open();
+          }, 1);
+        } else {
+          this.backdropElement.close();
+          this._manager.trackBackdrop(this);
+        }
+      }
+    },
+
     _toggleListener: function(enable, node, event, boundListener, capture) {
       if (enable) {
         // enable document-wide tap recognizer
@@ -298,14 +314,14 @@ context. You should place this element as a child of `<body>` whenever possible.
     _prepareRenderOpened: function() {
       this._manager.addOverlay(this);
 
-      if (this.withBackdrop) {
-        this.backdropElement.prepare();
-        this._manager.trackBackdrop(this);
-      }
-
       this._preparePositioning();
       this.fit();
       this._finishPositioning();
+
+      this._manager.trackBackdrop(this);
+      if (this.withBackdrop) {
+        this.backdropElement.prepare();
+      }
     },
 
     // tasks which cause the overlay to actually open; typically play an
@@ -338,7 +354,7 @@ context. You should place this element as a child of `<body>` whenever possible.
       // hide the overlay and remove the backdrop
       this.resetFit();
       this.style.display = 'none';
-      this._completeBackdrop();
+      this._manager.trackBackdrop(this);
       this._manager.removeOverlay(this);
 
       this._focusNode.blur();
@@ -347,13 +363,6 @@ context. You should place this element as a child of `<body>` whenever possible.
 
       this.notifyResize();
       this.fire('iron-overlay-closed', this.closingReason);
-    },
-
-    _completeBackdrop: function() {
-      if (this.withBackdrop) {
-        this._manager.trackBackdrop(this);
-        this.backdropElement.complete();
-      }
     },
 
     _preparePositioning: function() {

--- a/iron-overlay-manager.html
+++ b/iron-overlay-manager.html
@@ -28,10 +28,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     this._backdrops = [];
   }
 
-  Polymer.IronOverlayManagerClass.prototype._applyOverlayZ =
-      function(overlay, aboveZ) {
-        this._setZ(overlay, aboveZ + 2);
-      };
+  Polymer.IronOverlayManagerClass.prototype._applyOverlayZ = function(overlay, aboveZ) {
+    this._setZ(overlay, aboveZ + 2);
+  };
 
   Polymer.IronOverlayManagerClass.prototype._setZ = function(element, z) {
     element.style.zIndex = z;
@@ -47,7 +46,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     if (newZ <= minimumZ) {
       this._applyOverlayZ(overlay, minimumZ);
     }
-  },
+  };
 
   Polymer.IronOverlayManagerClass.prototype.removeOverlay = function(overlay) {
     var i = this._overlays.indexOf(overlay);
@@ -66,15 +65,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   };
 
   Polymer.IronOverlayManagerClass.prototype.currentOverlayZ = function() {
-    var z = this._minimumZ;
-    var current = this.currentOverlay();
-    if (current) {
-      var z1 = window.getComputedStyle(current).zIndex;
-      if (!isNaN(z1)) {
-        z = Number(z1);
-      }
-    }
-    return z;
+    return this._getOverlayZ(this.currentOverlay());
   };
 
   /**
@@ -105,19 +96,54 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   Polymer.IronOverlayManagerClass.prototype.trackBackdrop = function(element) {
     // backdrops contains the overlays with a backdrop that are currently
     // visible
-    if (element.opened) {
-      this._backdrops.push(element);
-    } else {
-      var index = this._backdrops.indexOf(element);
-      if (index >= 0) {
-        this._backdrops.splice(index, 1);
+    var index = this._backdrops.indexOf(element);
+    if (element.opened && element.withBackdrop) {
+      // no duplicates
+      if (index === -1) {
+        this._backdrops.push(element);
       }
+    } else if (index >= 0) {
+      this._backdrops.splice(index, 1);
     }
   };
 
   Polymer.IronOverlayManagerClass.prototype.getBackdrops = function() {
     return this._backdrops;
-  }
+  };
+
+  /**
+   * Returns the z-index for the backdrop.
+   */
+  Polymer.IronOverlayManagerClass.prototype.backdropZ = function() {
+    return this._getOverlayZ(this._overlayWithBackdrop()) - 1;
+  };
+
+  /**
+   * Returns the first opened overlay that has a backdrop.
+   */
+  Polymer.IronOverlayManagerClass.prototype._overlayWithBackdrop = function() {
+    for (var i = 0; i < this._overlays.length; i++) {
+      if (this._overlays[i].opened && this._overlays[i].withBackdrop) {
+        return this._overlays[i];
+      }
+    }
+  };
+
+  /**
+   * Calculates the minimum z-index for the overlay.
+   */
+  Polymer.IronOverlayManagerClass.prototype._getOverlayZ = function(overlay) {
+    var z = this._minimumZ;
+    if (overlay) {
+      var z1 = Number(window.getComputedStyle(overlay).zIndex);
+      // Check if is a number
+      // Number.isNaN not supported in IE 10+
+      if (z1 === z1) {
+        z = z1;
+      }
+    }
+    return z;
+  };
 
   Polymer.IronOverlayManager = new Polymer.IronOverlayManagerClass();
 

--- a/test/iron-overlay-behavior.html
+++ b/test/iron-overlay-behavior.html
@@ -471,6 +471,32 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           });
         });
 
+        test('updating with-backdrop to false closes backdrop', function(done) {
+          runAfterOpen(overlays[0], function() {
+            overlays[0].withBackdrop = false;
+            // Don't wait for animations.
+            overlays[0].backdropElement.complete();
+            
+            assert.isFalse(overlays[0].backdropElement.opened, 'backdrop is closed');
+            assert.isNotObject(overlays[0].backdropElement.parentNode, 'backdrop is removed from document');
+            done();
+          });
+        });
+
+        test('updating with-backdrop updates z-index', function(done) {
+          runAfterOpen(overlays[0], function() {
+            runAfterOpen(overlays[1], function() {
+              overlays[0].withBackdrop = false;
+              var styleZ = parseInt(window.getComputedStyle(overlays[0]).zIndex, 10);
+              var style1Z = parseInt(window.getComputedStyle(overlays[1]).zIndex, 10);
+              var bgStyleZ = parseInt(window.getComputedStyle(overlays[0].backdropElement).zIndex, 10);
+              assert.isTrue(style1Z > bgStyleZ, 'overlays[1] has higher z-index than backdrop');
+              assert.isTrue(styleZ < bgStyleZ, 'overlays[0] has lower z-index than backdrop');
+              done();
+            });
+          });
+        });
+
       });
 
       suite('a11y', function() {


### PR DESCRIPTION
Fixes #78 by adding an observer for `with-backdrop` changes.

`iron-overlay-manager` has a specific method to get the `z-index` for backdrop. This is done to make sure that backdrop's index is just below the first opened overlay that has `with-backdrop = true`. Also, its `trackBackdrop()` method now checks for duplicates and ensures that the passed element is opened and has a backdrop.

`iron-overlay-backdrop` will handle the call to `complete()` right after the transition ends. In addition, it updates its `z-index` on `prepare()` and on `close()`.

`iron-overlay-behavior` has been cleaned accordingly.