### PR TITLE
code cleanup & better handling event listeners 

### DIFF
--- a/iron-overlay-behavior.html
+++ b/iron-overlay-behavior.html
@@ -180,6 +180,7 @@ context. You should place this element as a child of `<body>` whenever possible.
      * Toggle the opened state of the overlay.
      */
     toggle: function() {
+      this._setCanceled(false);
       this.opened = !this.opened;
     },
 
@@ -187,16 +188,16 @@ context. You should place this element as a child of `<body>` whenever possible.
      * Open the overlay.
      */
     open: function() {
+      this._setCanceled(false);
       this.opened = true;
-      this.closingReason = {canceled: false};
     },
 
     /**
      * Close the overlay.
      */
     close: function() {
-      this.opened = false;
       this._setCanceled(false);
+      this.opened = false;
     },
 
     /**
@@ -208,8 +209,8 @@ context. You should place this element as a child of `<body>` whenever possible.
         return;
       }
 
-      this.opened = false;
       this._setCanceled(true);
+      this.opened = false;
     },
 
     _ensureSetup: function() {
@@ -234,17 +235,16 @@ context. You should place this element as a child of `<body>` whenever possible.
         this._callOpenedWhenReady = this.opened;
         return;
       }
-      if (this._openChangedAsync) {
-        this.cancelAsync(this._openChangedAsync);
-      }
-
-      this._toggleListeners();
 
       if (this.opened) {
         this._prepareRenderOpened();
       }
 
-      // async here to allow overlay layer to become visible.
+      if (this._openChangedAsync) {
+        this.cancelAsync(this._openChangedAsync);
+      }
+      // Async here to allow overlay layer to become visible, and to avoid
+      // listeners to immediately close via a click.
       this._openChangedAsync = this.async(function() {
         // overlay becomes visible here
         this.style.display = '';
@@ -256,9 +256,9 @@ context. You should place this element as a child of `<body>` whenever possible.
         } else {
           this._renderClosed();
         }
+        this._toggleListeners();
         this._openChangedAsync = null;
-      });
-
+      }, 1);
     },
 
     _canceledChanged: function() {
@@ -298,16 +298,9 @@ context. You should place this element as a child of `<body>` whenever possible.
       }
     },
 
-    _toggleListeners: function() {
-      if (this._toggleListenersAsync) {
-        this.cancelAsync(this._toggleListenersAsync);
-      }
-      // async so we don't auto-close immediately via a click.
-      this._toggleListenersAsync = this.async(function() {
-        this._toggleListener(this.opened, document, 'tap', this._boundOnCaptureClick, true);
-        this._toggleListener(this.opened, document, 'keydown', this._boundOnCaptureKeydown, true);
-        this._toggleListenersAsync = null;
-      }, 1);
+    _toggleListeners: function () {
+      this._toggleListener(this.opened, document, 'tap', this._boundOnCaptureClick, true);
+      this._toggleListener(this.opened, document, 'keydown', this._boundOnCaptureKeydown, true);
     },
 
     // tasks which must occur before opening; e.g. making the element visible
@@ -342,9 +335,7 @@ context. You should place this element as a child of `<body>` whenever possible.
 
     _finishRenderOpened: function() {
       // focus the child node with [autofocus]
-      if (!this.noAutoFocus) {
-        this._focusNode.focus();
-      }
+      this._applyFocus();
 
       this._observer = Polymer.dom(this).observeNodes(this.notifyResize);
       this.fire('iron-overlay-opened');
@@ -357,9 +348,7 @@ context. You should place this element as a child of `<body>` whenever possible.
       this._manager.trackBackdrop(this);
       this._manager.removeOverlay(this);
 
-      this._focusNode.blur();
-      // focus the next overlay, if there is one
-      this._manager.focusOverlay();
+      this._applyFocus();
 
       this.notifyResize();
       this.fire('iron-overlay-closed', this.closingReason);
@@ -391,8 +380,8 @@ context. You should place this element as a child of `<body>` whenever possible.
     },
 
     _onCaptureClick: function(event) {
-      if (!this.noCancelOnOutsideClick &&
-          this._manager.currentOverlay() === this &&
+      if (this._manager.currentOverlay() === this &&
+          !this.noCancelOnOutsideClick &&
           Polymer.dom(event).path.indexOf(this) === -1) {
         this.cancel();
       }
@@ -400,10 +389,10 @@ context. You should place this element as a child of `<body>` whenever possible.
 
     _onCaptureKeydown: function(event) {
       var ESC = 27;
-      if (!this.noCancelOnEscKey && (event.keyCode === ESC)) {
+      if (this._manager.currentOverlay() === this &&
+          !this.noCancelOnEscKey &&
+          event.keyCode === ESC) {
         this.cancel();
-        event.stopPropagation();
-        event.stopImmediatePropagation();
       }
     },
 

--- a/test/iron-overlay-behavior.html
+++ b/test/iron-overlay-behavior.html
@@ -113,8 +113,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           overlay = fixture('opened');
           overlay.addEventListener('iron-overlay-opened', function() {
             var s = getComputedStyle(overlay);
-            assert.isTrue(parseFloat(s.left) === (window.innerWidth - overlay.offsetWidth)/2, 'centered horizontally');
-            assert.isTrue(parseFloat(s.top) === (window.innerHeight - overlay.offsetHeight)/2, 'centered vertically');
+            assert.equal(parseFloat(s.left), (window.innerWidth - overlay.offsetWidth)/2, 'centered horizontally');
+            assert.equal(parseFloat(s.top), (window.innerHeight - overlay.offsetHeight)/2, 'centered vertically');
             done();
           });
         });
@@ -150,41 +150,41 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
 
         test('open() triggers iron-resize', function(done) {
-          // Skip potential `iron-resize` from window resizing
-          setTimeout(function () {
-            var spy = sinon.stub();
-            overlay.addEventListener('iron-resize', spy);
-            runAfterOpen(overlay, function () {
-              assert.isTrue(spy.calledOnce, 'iron-resize should be called once');
-              done();
-            });
+          // Ignore iron-resize triggered by window resize.
+          var callCount = 0;
+          window.addEventListener('resize', function() { callCount--; }, true);
+          overlay.addEventListener('iron-resize', function () { callCount++; });
+          runAfterOpen(overlay, function () {
+            assert.equal(callCount, 1, 'iron-resize should be called once');
+            done();
           });
         });
 
         test('closed overlay does not trigger iron-resize when its content changes', function(done) {
-          // Skip potential `iron-resize` from window resizing
-          setTimeout(function () {
-            var spy = sinon.stub();
-            overlay.addEventListener('iron-resize', spy);
-            var child = document.createElement('div');
-            child.innerHTML = 'hi';
-            Polymer.dom(overlay).appendChild(child);
-            overlay.async(function () {
-              assert.isFalse(spy.called, 'iron-resize should not be called');
-              done();
-            }, 10);
-          });
+          // Ignore iron-resize triggered by window resize.
+          var callCount = 0;
+          window.addEventListener('resize', function() { callCount--; }, true);
+          overlay.addEventListener('iron-resize', function () { callCount++; });
+          var child = document.createElement('div');
+          child.innerHTML = 'hi';
+          Polymer.dom(overlay).appendChild(child);
+          overlay.async(function () {
+            assert.equal(callCount, 0, 'iron-resize should not be called');
+            done();
+          }, 10);
         });
 
         test('open overlay triggers iron-resize when its content changes', function(done) {
           runAfterOpen(overlay, function () {
-            var spy = sinon.stub();
-            overlay.addEventListener('iron-resize', spy);
+            // Ignore iron-resize triggered by window resize.
+            var callCount = 0;
+            window.addEventListener('resize', function() { callCount--; }, true);
+            overlay.addEventListener('iron-resize', function () { callCount++; });
             var child = document.createElement('div');
             child.innerHTML = 'hi';
             Polymer.dom(overlay).appendChild(child);
             overlay.async(function () {
-              assert.isTrue(spy.calledOnce, 'iron-resize should be called once');
+              assert.equal(callCount, 1, 'iron-resize should be called once');
               done();
             }, 10);
           });
@@ -476,7 +476,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             overlays[0].withBackdrop = false;
             // Don't wait for animations.
             overlays[0].backdropElement.complete();
-            
+
             assert.isFalse(overlays[0].backdropElement.opened, 'backdrop is closed');
             assert.isNotObject(overlays[0].backdropElement.parentNode, 'backdrop is removed from document');
             done();


### PR DESCRIPTION
Fixes #27  by making sure `canceled` is set before updating `opened` (so that `closingReason` will be properly setup). 
Remove setting default value for booleans `canceled, withBackdrop, noAutoFocus, noCancelOnEscKey, noCancelOnOutsideClick`. 
Remove event listeners immediately after `opened` changes, and add them asynchronously if `opened = true`.
`_onCaptureKeydown` will not stop the event propagation but instead check if it is the current overlay (ensures the top one is closed)