### PR TITLE
immediately track backdrop on opened changes

### DIFF
--- a/iron-overlay-backdrop.html
+++ b/iron-overlay-backdrop.html
@@ -116,8 +116,8 @@ Custom property | Description | Default
     close: function() {
       // Always update z-index
       this.style.zIndex = this._manager.backdropZ();
-      // only need to make the backdrop invisible if this is called by the last overlay with a backdrop
-      if (this._manager.getBackdrops().length < 2) {
+      // close only if no element with backdrop is left
+      if (this._manager.getBackdrops().length === 0) {
         this._setOpened(false);
         // complete() will be called after the transition is done.
         // If animations are disabled via custom-styles, user is expected to call

--- a/iron-overlay-behavior.html
+++ b/iron-overlay-behavior.html
@@ -240,6 +240,8 @@ context. You should place this element as a child of `<body>` whenever possible.
 
       this._toggleListeners();
 
+      this._manager.trackBackdrop(this);
+
       if (this.opened) {
         this._prepareRenderOpened();
       }
@@ -268,8 +270,8 @@ context. You should place this element as a child of `<body>` whenever possible.
 
     _withBackdropChanged: function() {
       if (this.opened) {
+        this._manager.trackBackdrop(this);
         if (this.withBackdrop) {
-          this._manager.trackBackdrop(this);
           this.backdropElement.prepare();
           // Give time to be added to document.
           this.async(function(){
@@ -277,7 +279,6 @@ context. You should place this element as a child of `<body>` whenever possible.
           }, 1);
         } else {
           this.backdropElement.close();
-          this._manager.trackBackdrop(this);
         }
       }
     },
@@ -318,7 +319,6 @@ context. You should place this element as a child of `<body>` whenever possible.
       this.fit();
       this._finishPositioning();
 
-      this._manager.trackBackdrop(this);
       if (this.withBackdrop) {
         this.backdropElement.prepare();
       }
@@ -354,7 +354,6 @@ context. You should place this element as a child of `<body>` whenever possible.
       // hide the overlay and remove the backdrop
       this.resetFit();
       this.style.display = 'none';
-      this._manager.trackBackdrop(this);
       this._manager.removeOverlay(this);
 
       this._focusNode.blur();

--- a/test/iron-overlay-behavior.html
+++ b/test/iron-overlay-behavior.html
@@ -445,6 +445,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             done();
           });
         });
+
+        test('manager backdrops immediately updated on opened changes', function() {
+          overlays[0].opened = true;
+          assert.equal(overlays[0]._manager.getBackdrops().length, 1, 'overlay added to manager backdrops');
+          overlays[0].opened = false;
+          assert.equal(overlays[0]._manager.getBackdrops().length, 0, 'overlay removed from manager backdrops');
+        });
       });
 
       suite('multiple overlays with backdrop', function() {
@@ -476,7 +483,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             overlays[0].withBackdrop = false;
             // Don't wait for animations.
             overlays[0].backdropElement.complete();
-            
+
             assert.isFalse(overlays[0].backdropElement.opened, 'backdrop is closed');
             assert.isNotObject(overlays[0].backdropElement.parentNode, 'backdrop is removed from document');
             done();


### PR DESCRIPTION
Fixes https://github.com/PolymerElements/paper-dialog/issues/77 by updating the manager's `backdrops` array on open changed.
Without this fix, when we add transitions to an overlay, it might be that they take longer than the animation of the backdrop. The manager needs to be updated as soon as possible so that once the backdrop is done, it can safely rely on the `manager.getBackdrops()` to be of the right length