### PR TITLE
with-backdrop traps focus within overlay

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -19,16 +19,15 @@
     "url": "git://github.com/PolymerElements/iron-overlay-behavior.git"
   },
   "dependencies": {
-    "polymer": "Polymer/polymer#^1.0.0",
     "iron-fit-behavior": "PolymerElements/iron-fit-behavior#^1.0.0",
-    "iron-resizable-behavior": "PolymerElements/iron-resizable-behavior#^1.0.0"
+    "iron-resizable-behavior": "PolymerElements/iron-resizable-behavior#^1.0.0",
+    "polymer": "Polymer/polymer#^1.0.0"
   },
   "devDependencies": {
-    "paper-styles": "polymerelements/paper-styles#^1.0.2",
     "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
     "iron-flex-layout": "PolymerElements/iron-flex-layout#^1.0.0",
     "iron-test-helpers": "PolymerElements/iron-test-helpers#^1.0.0",
-    "test-fixture": "PolymerElements/test-fixture#^1.0.0",
+    "paper-styles": "PolymerElements/paper-styles#^1.0.2",
     "web-component-tester": "^4.0.0",
     "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0"
   },

--- a/demo/index.html
+++ b/demo/index.html
@@ -120,7 +120,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       <button data-dialog="backdrop">backdrop</button>
 
       <simple-overlay id="backdrop" with-backdrop>
-        Hello world!
+        <p>Hello world!</p>
+        <button>button</button>
+        <button>button</button>
+        <button>button</button>
       </simple-overlay>
 
       <button data-dialog="autofocus">autofocus</button>

--- a/iron-overlay-behavior.html
+++ b/iron-overlay-behavior.html
@@ -135,6 +135,18 @@ context. You should place this element as a child of `<body>` whenever possible.
         value: function() {
           return this._onCaptureKeydown.bind(this);
         }
+      },
+
+      _boundOnCaptureFocus: {
+        type: Function,
+        value: function() {
+          return this._onCaptureFocus.bind(this);
+        }
+      },
+
+      /** @type {?Node} */
+      _focusedChild: {
+        type: Object
       }
 
     },
@@ -152,10 +164,13 @@ context. You should place this element as a child of `<body>` whenever possible.
     },
 
     get _focusNode() {
-      return Polymer.dom(this).querySelector('[autofocus]') || this;
+      return this._focusedChild || Polymer.dom(this).querySelector('[autofocus]') || this;
     },
 
     ready: function() {
+      // with-backdrop need tabindex to be set in order to trap the focus.
+      // If it is not set, IronOverlayBehavior will set it, and remove it if with-backdrop = false.
+      this.__shouldRemoveTabIndex = false;
       this._ensureSetup();
     },
 
@@ -265,6 +280,14 @@ context. You should place this element as a child of `<body>` whenever possible.
     },
 
     _withBackdropChanged: function() {
+      // If tabindex is already set, no need to override it.
+      if (this.withBackdrop && !this.hasAttribute('tabindex')) {
+        this.setAttribute('tabindex', '-1');
+        this.__shouldRemoveTabIndex = true;
+      } else if (this.__shouldRemoveTabIndex) {
+        this.removeAttribute('tabindex');
+        this.__shouldRemoveTabIndex = false;
+      }
       if (this.opened) {
         this._manager.trackBackdrop(this);
         if (this.withBackdrop) {
@@ -298,6 +321,7 @@ context. You should place this element as a child of `<body>` whenever possible.
     _toggleListeners: function () {
       this._toggleListener(this.opened, document, 'tap', this._boundOnCaptureClick, true);
       this._toggleListener(this.opened, document, 'keydown', this._boundOnCaptureKeydown, true);
+      this._toggleListener(this.opened, document, 'focus', this._boundOnCaptureFocus, true);
     },
 
     // tasks which must occur before opening; e.g. making the element visible
@@ -343,6 +367,7 @@ context. You should place this element as a child of `<body>` whenever possible.
       this.style.display = 'none';
       this._manager.removeOverlay(this);
 
+      this._focusedChild = null;
       this._applyFocus();
 
       this.notifyResize();
@@ -376,9 +401,12 @@ context. You should place this element as a child of `<body>` whenever possible.
 
     _onCaptureClick: function(event) {
       if (this._manager.currentOverlay() === this &&
-          !this.noCancelOnOutsideClick &&
           Polymer.dom(event).path.indexOf(this) === -1) {
-        this.cancel();
+        if (this.noCancelOnOutsideClick) {
+          this._applyFocus();
+        } else {
+          this.cancel();
+        }
       }
     },
 
@@ -388,6 +416,19 @@ context. You should place this element as a child of `<body>` whenever possible.
           !this.noCancelOnEscKey &&
           event.keyCode === ESC) {
         this.cancel();
+      }
+    },
+
+    _onCaptureFocus: function (event) {
+      if (this._manager.currentOverlay() === this &&
+          this.withBackdrop) {
+        var path = Polymer.dom(event).path;
+        if (path.indexOf(this) === -1) {
+          event.stopPropagation();
+          this._applyFocus();
+        } else {
+          this._focusedChild = path[0];
+        }
       }
     },
 

--- a/test/iron-overlay-behavior.html
+++ b/test/iron-overlay-behavior.html
@@ -323,6 +323,19 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           });
         });
 
+        test('no-cancel-on-outside-click property; focus stays on overlay when click outside', function(done) {
+          overlay = fixture('autofocus');
+          overlay.noCancelOnOutsideClick = true;
+          runAfterOpen(overlay, function() {
+            MockInteractions.tap(document.body);
+            setTimeout(function() {
+              assert.equal(Polymer.dom(overlay).querySelector('[autofocus]'), document.activeElement, '<button autofocus> is focused');
+              done();
+            }, 10);
+          });
+        });
+
+
         test('no-cancel-on-esc-key property', function(done) {
           overlay.noCancelOnEscKey = true;
           runAfterOpen(overlay, function() {
@@ -466,6 +479,41 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           assert.equal(overlays[0]._manager.getBackdrops().length, 0, 'overlay removed from manager backdrops');
         });
 
+        test('with-backdrop sets tabindex=-1 and removes it', function() {
+          var overlay = fixture('basic');
+          overlay.withBackdrop = true;
+          assert.equal(overlay.getAttribute('tabindex'), '-1', 'tabindex is -1');
+          overlay.withBackdrop = false;
+          assert.isFalse(overlay.hasAttribute('tabindex'), 'tabindex removed');
+        });
+
+        test('with-backdrop does not override tabindex if already set', function() {
+          var overlay = fixture('basic');
+          overlay.setAttribute('tabindex', '1');
+          overlay.withBackdrop = true;
+          assert.equal(overlay.getAttribute('tabindex'), '1', 'tabindex is 1');
+          overlay.withBackdrop = false;
+          assert.equal(overlay.getAttribute('tabindex'), '1', 'tabindex is still 1');
+        });
+
+        test('with-backdrop traps the focus within the overlay', function(done) {
+          // Add button to try to "steal" focus.
+          var button = document.createElement('button');
+          var focusSpy = sinon.stub();
+          button.addEventListener('focus', focusSpy, true);
+          document.body.appendChild(button);
+
+          var overlay = fixture('autofocus');
+          overlay.withBackdrop = true;
+          runAfterOpen(overlay, function() {
+            // Try to steal the focus
+            MockInteractions.focus(button);
+            assert.isFalse(focusSpy.called, 'button in body did not get the focus');
+            assert.equal(Polymer.dom(overlay).querySelector('[autofocus]'), document.activeElement, '<button autofocus> is focused');
+            button.parentNode.removeChild(button);
+            done();
+          });
+        });
       });
 
       suite('multiple overlays with backdrop', function() {

--- a/test/test-buttons.html
+++ b/test/test-buttons.html
@@ -1,0 +1,40 @@
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+
+<link rel="import" href="../../polymer/polymer.html">
+
+<dom-module id="test-buttons">
+
+  <style>
+
+    :host {
+      border: 1px solid black;
+      padding: 10px;
+    }
+
+  </style>
+
+  <template>
+    <button id="button0">button0</button>
+    <button id="button1">button1</button>
+    <button id="button2">button2</button>
+  </template>
+
+</dom-module>
+
+<script>
+
+(function() {
+  Polymer({
+    is: 'test-buttons'
+  });
+})();
+
+</script>


### PR DESCRIPTION
Fixes #88 by listening to focus changes on document.
`with-backdrop` will set the `tabindex` to `-1` so that focus can be trapped within the overlay.