### PR TITLE
call complete() if transitionDuration = 0s

### DIFF
--- a/iron-overlay-backdrop.html
+++ b/iron-overlay-backdrop.html
@@ -119,9 +119,10 @@ Custom property | Description | Default
       // close only if no element with backdrop is left
       if (this._manager.getBackdrops().length === 0) {
         this._setOpened(false);
-        // complete() will be called after the transition is done.
-        // If animations are disabled via custom-styles, user is expected to call
-        // complete() after close()
+        // In case of no animations, complete
+        if (getComputedStyle(this).transitionDuration === '0s') {
+          this.complete();
+        }
       }
     },
 

--- a/iron-overlay-backdrop.html
+++ b/iron-overlay-backdrop.html
@@ -118,9 +118,12 @@ Custom property | Description | Default
       this.style.zIndex = this._manager.backdropZ();
       // close only if no element with backdrop is left
       if (this._manager.getBackdrops().length === 0) {
+        // Read style before setting opened.
+        var cs = getComputedStyle(this);
+        var noAnimation = (cs.transitionDuration === '0s' || cs.opacity == 0);
         this._setOpened(false);
         // In case of no animations, complete
-        if (getComputedStyle(this).transitionDuration === '0s') {
+        if (noAnimation) {
           this.complete();
         }
       }

--- a/test/iron-overlay-behavior.html
+++ b/test/iron-overlay-behavior.html
@@ -465,6 +465,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           overlays[0].opened = false;
           assert.equal(overlays[0]._manager.getBackdrops().length, 0, 'overlay removed from manager backdrops');
         });
+
       });
 
       suite('multiple overlays with backdrop', function() {
@@ -500,8 +501,21 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
             assert.isFalse(overlays[0].backdropElement.opened, 'backdrop is closed');
             assert.isNotObject(overlays[0].backdropElement.parentNode, 'backdrop is removed from document');
+            overlays[0].backdropElement.style.transitionDuration = '';
             done();
           });
+        });
+
+        test('backdrop is removed when toggling overlay opened', function(done) {
+          overlays[0].open();
+          assert.isObject(overlays[0].backdropElement.parentNode, 'backdrop is immediately inserted in the document');
+          overlays[0].close();
+          // Wait a tick (overlay will call backdropElement.close in the _openChangedAsync)
+          setTimeout(function() {
+            assert.isFalse(overlays[0].backdropElement.opened, 'backdrop is closed');
+            assert.isNotObject(overlays[0].backdropElement.parentNode, 'backdrop is removed from document');
+            done();
+          }, 1);
         });
 
         test('updating with-backdrop updates z-index', function(done) {

--- a/test/iron-overlay-behavior.html
+++ b/test/iron-overlay-behavior.html
@@ -492,10 +492,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
 
         test('updating with-backdrop to false closes backdrop', function(done) {
+          // no waiting for animations
+          overlays[0].backdropElement.style.transitionDuration = '0s';
+
           runAfterOpen(overlays[0], function() {
             overlays[0].withBackdrop = false;
-            // Don't wait for animations.
-            overlays[0].backdropElement.complete();
 
             assert.isFalse(overlays[0].backdropElement.opened, 'backdrop is closed');
             assert.isNotObject(overlays[0].backdropElement.parentNode, 'backdrop is removed from document');


### PR DESCRIPTION
Fixes #83 by checking for css `transitionDuration` when closing the backdrop and calling `complete()` if duration is `0s`
Fixes #96 by checking of css `opacity` when closing the backdrop and calling `complete()` if `opacity` is already 0.
Updated previous test that was relying on disabling the animations.