### PR TITLE
add no-auto-focus test

### DIFF
--- a/iron-overlay-behavior.html
+++ b/iron-overlay-behavior.html
@@ -327,6 +327,7 @@ context. You should place this element as a child of `<body>` whenever possible.
 
     // tasks which must occur before opening; e.g. making the element visible
     _prepareRenderOpened: function() {
+
       this._manager.addOverlay(this);
 
       this._preparePositioning();
@@ -335,6 +336,12 @@ context. You should place this element as a child of `<body>` whenever possible.
 
       if (this.withBackdrop) {
         this.backdropElement.prepare();
+      }
+
+      // Safari will apply the focus to the autofocus element when displayed for the first time,
+      // so we blur it. Later, _applyFocus will set the focus if necessary.
+      if (this.noAutoFocus && document.activeElement === this._focusNode) {
+        this._focusNode.blur();
       }
     },
 

--- a/test/iron-overlay-behavior.html
+++ b/test/iron-overlay-behavior.html
@@ -340,6 +340,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           });
         });
 
+        test('no-auto-focus will not focus node with autofocus', function(done) {
+          overlay.noAutoFocus = true;
+          runAfterOpen(overlay, function() {
+            assert.notEqual(Polymer.dom(overlay).querySelector('[autofocus]'), document.activeElement, '<button autofocus> not focused after opened');
+            done();
+          });
+          // In Safari the element with autofocus will immediately receive focus when displayed for the first time http://jsbin.com/woroci/2/
+          // Ensure this is not the case for overlay.
+          assert.notEqual(Polymer.dom(overlay).querySelector('[autofocus]'), document.activeElement, '<button autofocus> not immediately focused');
+        });
+
         test('no-cancel-on-outside-click property; focus stays on overlay when click outside', function(done) {
           overlay.noCancelOnOutsideClick = true;
           runAfterOpen(overlay, function() {


### PR DESCRIPTION
Added tests for `no-auto-focus` property. Discovered "funky" behavior on Safari where if an element with `autofocus` attribute is displayed for the first time, it will receive the focus (tested with `button`, see example here http://jsbin.com/woroci/2/). So now `iron-overlay-behavior` handles also that case, making sure that the element is blurred synchronously after `overlay.open()` gets called.