### PR TITLE
Fixes #69 by passing the original click event to the cancel  function 

### DIFF
--- a/iron-overlay-behavior.html
+++ b/iron-overlay-behavior.html
@@ -212,10 +212,11 @@ context. You should place this element as a child of `<body>` whenever possible.
     },
 
     /**
-     * Cancels the overlay.
+     * Cancels the overlay. 
+     * @param {?Event} event The original event
      */
-    cancel: function() {
-      var cancelEvent = this.fire('iron-overlay-canceled', undefined, {cancelable: true});
+    cancel: function(event) {
+      var cancelEvent = this.fire('iron-overlay-canceled', event, {cancelable: true});
       if (cancelEvent.defaultPrevented) {
         return;
       }
@@ -405,7 +406,7 @@ context. You should place this element as a child of `<body>` whenever possible.
         if (this.noCancelOnOutsideClick) {
           this._applyFocus();
         } else {
-          this.cancel();
+          this.cancel(event);
         }
       }
     },
@@ -415,7 +416,7 @@ context. You should place this element as a child of `<body>` whenever possible.
       if (this._manager.currentOverlay() === this &&
           !this.noCancelOnEscKey &&
           event.keyCode === ESC) {
-        this.cancel();
+        this.cancel(event);
       }
     },
 
@@ -447,6 +448,7 @@ context. You should place this element as a child of `<body>` whenever possible.
  * Fired when the `iron-overlay` is canceled, but before it is closed.
  * Cancel the event to prevent the `iron-overlay` from closing.
  * @event iron-overlay-canceled
+ * @param {?Event} event The event in case the user pressed ESC or clicked outside the overlay
  */
 
 /**

--- a/test/iron-overlay-behavior.html
+++ b/test/iron-overlay-behavior.html
@@ -256,6 +256,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         test('cancel an overlay by clicking outside', function(done) {
           runAfterOpen(overlay, function() {
             overlay.addEventListener('iron-overlay-canceled', function(event) {
+              assert.equal(event.detail.target, document.body, 'detail contains original click event');
               done();
             });
             MockInteractions.tap(document.body);
@@ -290,6 +291,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         test('cancel an overlay with esc key', function(done) {
           runAfterOpen(overlay, function() {
             overlay.addEventListener('iron-overlay-canceled', function(event) {
+              assert.equal(event.detail.type, 'keydown');
               done();
             });
             fireEvent('keydown', {


### PR DESCRIPTION
Fixes #69 by passing the source event to the close functions and the iron-overlay-canceled event. 