### PR TITLE
remove autofocus of first element

### DIFF
--- a/iron-overlay-behavior.html
+++ b/iron-overlay-behavior.html
@@ -179,7 +179,7 @@ context. You should place this element as a child of `<body>` whenever possible.
      * @type {Node}
      */
     get _focusNode() {
-      return this._focusedChild || Polymer.dom(this).querySelector('[autofocus]') || this.__firstFocusableNode || this;
+      return this._focusedChild || Polymer.dom(this).querySelector('[autofocus]') || this;
     },
 
     /**

--- a/test/iron-overlay-behavior.html
+++ b/test/iron-overlay-behavior.html
@@ -453,13 +453,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           assert.equal(focusableNodes[5], Polymer.dom(overlayWithTabIndex).querySelector('.focusable6'));
         });
 
-        test('first focusable is focused if no [autofocus] node is present', function(done) {
-          runAfterOpen(overlay, function() {
-            assert.equal(Polymer.dom(overlay).querySelector('.focusable1'), document.activeElement, 'focusable1 is focused');
-            done();
-          });
-        });
-
         test('with-backdrop: TAB & Shift+TAB wrap focus', function(done) {
           overlay.withBackdrop = true;
           var focusableNodes = overlay._focusableNodes;


### PR DESCRIPTION
revert the auto focusing of the first focusable element, since it is a breaking change (introduced in https://github.com/PolymerElements/iron-overlay-behavior/pull/106) that no-one asked.