### PR TITLE
call notifyResize only when not animating. Call refit only once on opened changes.

### DIFF
--- a/iron-overlay-behavior.html
+++ b/iron-overlay-behavior.html
@@ -243,6 +243,8 @@ context. You should place this element as a child of `<body>` whenever possible.
     },
 
     ready: function() {
+      // Used to skip calls to notifyResize and refit while the overlay is animating.
+      this.__isAnimating = false;
       // with-backdrop needs tabindex to be set in order to trap the focus.
       // If it is not set, IronOverlayBehavior will set it, and remove it if with-backdrop = false.
       this.__shouldRemoveTabIndex = false;
@@ -328,6 +330,7 @@ context. You should place this element as a child of `<body>` whenever possible.
 
       this._manager.trackBackdrop(this);
 
+      this.__isAnimating = true;
       if (this.opened) {
         this._prepareRenderOpened();
       }
@@ -410,7 +413,7 @@ context. You should place this element as a child of `<body>` whenever possible.
       // Needed to calculate the size of the overlay so that transitions on its size
       // will have the correct starting points.
       this._preparePositioning();
-      this.fit();
+      this.refit();
       this._finishPositioning();
 
       if (this.withBackdrop) {
@@ -441,24 +444,23 @@ context. You should place this element as a child of `<body>` whenever possible.
     },
 
     _finishRenderOpened: function() {
-      // This ensures the overlay is visible before we set the focus
-      // (by calling _onIronResize -> refit).
-      this.notifyResize();
       // Focus the child node with [autofocus]
       this._applyFocus();
 
+      this.notifyResize();
+      this.__isAnimating = false;
       this.fire('iron-overlay-opened');
     },
 
     _finishRenderClosed: function() {
       // Hide the overlay and remove the backdrop.
-      this.resetFit();
       this.style.display = 'none';
       this._manager.removeOverlay(this);
 
       this._applyFocus();
-      this.notifyResize();
 
+      this.notifyResize();
+      this.__isAnimating = false;
       this.fire('iron-overlay-closed', this.closingReason);
     },
 
@@ -513,6 +515,10 @@ context. You should place this element as a child of `<body>` whenever possible.
     },
 
     _onIronResize: function() {
+      if (this.__isAnimating) {
+        return;
+      }
+
       if (this.opened) {
         this.refit();
       }
@@ -524,7 +530,7 @@ context. You should place this element as a child of `<body>` whenever possible.
      * Can be overridden in order to avoid multiple observers on the same node.
      */
     _onNodesChange: function() {
-      if (this.opened) {
+      if (this.opened && !this.__isAnimating) {
         this.notifyResize();
       }
       // Store it so we don't query too much.

--- a/test/iron-overlay-behavior.html
+++ b/test/iron-overlay-behavior.html
@@ -165,8 +165,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
 
         test('open() triggers iron-resize', function(done) {
-          // Ignore the iron-resize on attached.
-          var callCount = -1;
+          var callCount = 0;
           // Ignore iron-resize triggered by window resize.
           window.addEventListener('resize', function() { callCount--; }, true);
           overlay.addEventListener('iron-resize', function() { callCount++; });
@@ -359,10 +358,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           });
         });
 
-        test('open overlay refits on iron-resize', function() {
+        test('open overlay refits on iron-resize', function(done) {
           var spy = sinon.spy(overlay, 'refit');
+          // At this point, overlay is still opening.
           overlay.fire('iron-resize');
-          assert.isTrue(spy.called, 'overlay should refit');
+          assert.isFalse(spy.called, 'overlay did not refit while animating');
+          overlay.addEventListener('iron-overlay-opened', function() {
+            overlay.fire('iron-resize');
+            assert.isTrue(spy.called, 'overlay did refit');
+            done();
+          });
         });
 
       });


### PR DESCRIPTION
Fixes #113 by calling `refit` on `_prepareRenderedOpened`. Moreover limit the calls to `notifyResize` when the animation is ongoing; also in `_onIronResize` callback, we don't call `refit` if the animation is not done yet. Updated tests accordingly.

This helps fixing issues like [this one on `iron-dropdown`](https://github.com/PolymerElements/iron-dropdown/pull/63#issuecomment-187840348): what happens there is that `_prepareRenderOpened` calls only `fit`, so it won't recalculate the position information when `opened` changes. This PR makes sure we call `refit` right when (and only when) it is needed.