### PR TITLE
Click, focus, keydown listeners on manager

### DIFF
--- a/iron-overlay-backdrop.html
+++ b/iron-overlay-backdrop.html
@@ -95,8 +95,6 @@ Custom property | Description | Default
      * Appends the backdrop to document body and sets its `z-index` to be below the latest overlay.
      */
     prepare: function() {
-      // Always update z-index
-      this.style.zIndex = this._manager.backdropZ();
       if (!this.parentNode) {
         Polymer.dom(document.body).appendChild(this);
       }
@@ -116,8 +114,6 @@ Custom property | Description | Default
      * Hides the backdrop if needed.
      */
     close: function() {
-      // Always update z-index
-      this.style.zIndex = this._manager.backdropZ();
       // close only if no element with backdrop is left
       if (this._manager.getBackdrops().length === 0) {
         // Read style before setting opened.

--- a/iron-overlay-behavior.html
+++ b/iron-overlay-behavior.html
@@ -9,7 +9,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 -->
 
 <link rel="import" href="../polymer/polymer.html">
-<link rel="import" href="../iron-a11y-keys-behavior/iron-a11y-keys-behavior.html">
 <link rel="import" href="../iron-fit-behavior/iron-fit-behavior.html">
 <link rel="import" href="../iron-resizable-behavior/iron-resizable-behavior.html">
 <link rel="import" href="iron-overlay-backdrop.html">
@@ -120,15 +119,6 @@ context. You should place this element as a child of `<body>` whenever possible.
       },
 
       /**
-       * The HTMLElement that will be firing relevant KeyboardEvents.
-       * Used for capturing esc and tab. Overridden from `IronA11yKeysBehavior`.
-       */
-      keyEventTarget: {
-        type: Object,
-        value: document
-      },
-
-      /**
        * Set to true to enable restoring of focus when overlay is closed.
        */
       restoreFocusOnClose: {
@@ -146,20 +136,6 @@ context. You should place this element as a child of `<body>` whenever possible.
         value: Polymer.IronOverlayManager
       },
 
-      _boundOnCaptureClick: {
-        type: Function,
-        value: function() {
-          return this._onCaptureClick.bind(this);
-        }
-      },
-
-      _boundOnCaptureFocus: {
-        type: Function,
-        value: function() {
-          return this._onCaptureFocus.bind(this);
-        }
-      },
-
       /**
        * The node being focused.
        * @type {?Node}
@@ -168,11 +144,6 @@ context. You should place this element as a child of `<body>` whenever possible.
         type: Object
       }
 
-    },
-
-    keyBindings: {
-      'esc': '__onEsc',
-      'tab': '__onTab'
     },
 
     listeners: {
@@ -335,18 +306,20 @@ context. You should place this element as a child of `<body>` whenever possible.
         return;
       }
 
-      this._manager.trackBackdrop(this);
-
       this.__isAnimating = true;
+
       if (this.opened) {
         this._prepareRenderOpened();
+      } else {
+        this._manager.removeOverlay(this);
       }
+
+      this._manager.trackBackdrop(this);
 
       if (this._openChangedAsync) {
         this.cancelAsync(this._openChangedAsync);
       }
-      // Async here to allow overlay layer to become visible, and to avoid
-      // listeners to immediately close via a click.
+      // Async here to allow overlay layer to become visible.
       this._openChangedAsync = this.async(function() {
         // overlay becomes visible here
         this.style.display = '';
@@ -358,7 +331,6 @@ context. You should place this element as a child of `<body>` whenever possible.
         } else {
           this._renderClosed();
         }
-        this._toggleListeners();
         this._openChangedAsync = null;
       }, 1);
     },
@@ -391,28 +363,10 @@ context. You should place this element as a child of `<body>` whenever possible.
       }
     },
 
-    _toggleListener: function(enable, node, event, boundListener, capture) {
-      if (enable) {
-        // enable document-wide tap recognizer
-        if (event === 'tap') {
-          Polymer.Gestures.add(document, 'tap', null);
-        }
-        node.addEventListener(event, boundListener, capture);
-      } else {
-        // disable document-wide tap recognizer
-        if (event === 'tap') {
-          Polymer.Gestures.remove(document, 'tap', null);
-        }
-        node.removeEventListener(event, boundListener, capture);
-      }
-    },
-
-    _toggleListeners: function() {
-      this._toggleListener(this.opened, document, 'tap', this._boundOnCaptureClick, true);
-      this._toggleListener(this.opened, document, 'focus', this._boundOnCaptureFocus, true);
-    },
-
-    // tasks which must occur before opening; e.g. making the element visible
+    /**
+     * tasks which must occur before opening; e.g. making the element visible.
+     * @protected
+     */
     _prepareRenderOpened: function() {
 
       this._manager.addOverlay(this);
@@ -434,8 +388,10 @@ context. You should place this element as a child of `<body>` whenever possible.
       }
     },
 
-    // tasks which cause the overlay to actually open; typically play an
-    // animation
+    /**
+     * Tasks which cause the overlay to actually open; typically play an animation.
+     * @protected
+     */
     _renderOpened: function() {
       if (this.withBackdrop) {
         this.backdropElement.open();
@@ -443,6 +399,10 @@ context. You should place this element as a child of `<body>` whenever possible.
       this._finishRenderOpened();
     },
 
+    /**
+     * Tasks which cause the overlay to actually close; typically play an animation.
+     * @protected
+     */
     _renderClosed: function() {
       if (this.withBackdrop) {
         this.backdropElement.close();
@@ -450,6 +410,10 @@ context. You should place this element as a child of `<body>` whenever possible.
       this._finishRenderClosed();
     },
 
+    /**
+     * Tasks to be performed at the end of open action. Will fire `iron-overlay-opened`.
+     * @protected
+     */
     _finishRenderOpened: function() {
       // Focus the child node with [autofocus]
       this._applyFocus();
@@ -459,10 +423,13 @@ context. You should place this element as a child of `<body>` whenever possible.
       this.fire('iron-overlay-opened');
     },
 
+    /**
+     * Tasks to be performed at the end of close action. Will fire `iron-overlay-closed`.
+     * @protected
+     */
     _finishRenderClosed: function() {
       // Hide the overlay and remove the backdrop.
       this.style.display = 'none';
-      this._manager.removeOverlay(this);
 
       this._applyFocus();
 
@@ -486,6 +453,10 @@ context. You should place this element as a child of `<body>` whenever possible.
       this.style.transition = this.style.webkitTransition = '';
     },
 
+    /**
+     * Applies focus according to the opened state.
+     * @protected
+     */
     _applyFocus: function() {
       if (this.opened) {
         if (!this.noAutoFocus) {
@@ -498,29 +469,69 @@ context. You should place this element as a child of `<body>` whenever possible.
       }
     },
 
+    /**
+     * Cancels (closes) the overlay. Call when click happens outside the overlay.
+     * @param {!Event} event
+     * @protected
+     */
     _onCaptureClick: function(event) {
-      if (this._manager.currentOverlay() === this &&
-          Polymer.dom(event).path.indexOf(this) === -1) {
-        if (this.noCancelOnOutsideClick) {
-          this._applyFocus();
-        } else {
-          this.cancel(event);
-        }
+      if (!this.noCancelOnOutsideClick) {
+        this.cancel(event);
       }
     },
 
+    /**
+     * Keeps track of the focused child. If withBackdrop, traps focus within overlay.
+     * @param {!Event} event
+     * @protected
+     */
     _onCaptureFocus: function (event) {
-      if (this._manager.currentOverlay() === this && this.withBackdrop) {
-        var path = Polymer.dom(event).path;
-        if (path.indexOf(this) === -1) {
-          event.stopPropagation();
-          this._applyFocus();
-        } else {
-          this._focusedChild = path[0];
-        }
+      if (!this.withBackdrop) {
+        return;
+      }
+      var path = Polymer.dom(event).path;
+      if (path.indexOf(this) === -1) {
+        event.stopPropagation();
+        this._applyFocus();
+      } else {
+        this._focusedChild = path[0];
       }
     },
 
+    /**
+     * Handles the ESC key event and cancels (closes) the overlay.
+     * @param {!Event} event
+     * @protected
+     */
+    _onCaptureEsc: function(event) {
+      if (!this.noCancelOnEscKey) {
+        this.cancel(event);
+      }
+    },
+
+    /**
+     * Handles TAB key events to track focus changes.
+     * Will wrap focus for overlays withBackdrop.
+     * @param {!Event} event
+     * @protected
+     */
+    _onCaptureTab: function(event) {
+      // TAB wraps from last to first focusable.
+      // Shift + TAB wraps from first to last focusable.
+      var shift = event.shiftKey;
+      var nodeToCheck = shift ? this.__firstFocusableNode : this.__lastFocusableNode;
+      var nodeToSet = shift ? this.__lastFocusableNode : this.__firstFocusableNode;
+      if (this.withBackdrop && this._focusedChild === nodeToCheck) {
+        // We set here the _focusedChild so that _onCaptureFocus will handle the
+        // wrapping of the focus (the next event after tab is focus).
+        this._focusedChild = nodeToSet;
+      }
+    },
+
+    /**
+     * Refits if the overlay is opened and not animating.
+     * @protected
+     */
     _onIronResize: function() {
       if (this.__isAnimating) {
         return;
@@ -532,9 +543,9 @@ context. You should place this element as a child of `<body>` whenever possible.
     },
 
     /**
-     * @protected
      * Will call notifyResize if overlay is opened.
      * Can be overridden in order to avoid multiple observers on the same node.
+     * @protected
      */
     _onNodesChange: function() {
       if (this.opened && !this.__isAnimating) {
@@ -544,33 +555,6 @@ context. You should place this element as a child of `<body>` whenever possible.
       var focusableNodes = this._focusableNodes;
       this.__firstFocusableNode = focusableNodes[0];
       this.__lastFocusableNode = focusableNodes[focusableNodes.length - 1];
-    },
-
-    __onEsc: function(event) {
-      // Not opened or not on top, so return.
-      if (this._manager.currentOverlay() !== this) {
-        return;
-      }
-      if (!this.noCancelOnEscKey) {
-        this.cancel(event);
-      }
-    },
-
-    __onTab: function(event) {
-      // Not opened or not on top, so return.
-      if (this._manager.currentOverlay() !== this) {
-        return;
-      }
-      // TAB wraps from last to first focusable.
-      // Shift + TAB wraps from first to last focusable.
-      var shift = event.detail.keyboardEvent.shiftKey;
-      var nodeToCheck = shift ? this.__firstFocusableNode : this.__lastFocusableNode;
-      var nodeToSet = shift ? this.__lastFocusableNode : this.__firstFocusableNode;
-      if (this.withBackdrop && this._focusedChild === nodeToCheck) {
-        // We set here the _focusedChild so that _onCaptureFocus will handle the
-        // wrapping of the focus (the next event after tab is focus).
-        this._focusedChild = nodeToSet;
-      }
     }
   };
 

--- a/iron-overlay-manager.html
+++ b/iron-overlay-manager.html
@@ -9,6 +9,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 -->
 
 <link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../iron-a11y-keys-behavior/iron-a11y-keys-behavior.html">
 
 <script>
 
@@ -25,12 +26,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     this._overlays = [];
 
     /**
-     * Used to keep track of the last focused node before an overlay gets opened.
-     * @private {Array<Element>}
-     */
-    this._lastFocusedNodes = [];
-
-    /**
      * iframes have a default z-index of 100,
      * so this default should be at least that.
      * @private {number}
@@ -38,16 +33,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     this._minimumZ = 101;
 
     /**
-     * Used to keep track of the opened overlays with backdrop.
-     * @private {Array<Element>}
-     */
-    this._backdrops = [];
-
-    /**
      * Memoized backdrop element.
      * @private {Element|null}
      */
     this._backdropElement = null;
+
+    // Enable document-wide tap recognizer.
+    Polymer.Gestures.add(document, 'tap', null);
+    // We should be using only 'tap', but this would be a breaking change.
+    var tapEvent = ('ontouchstart' in window) ? 'tap' : 'click';
+    document.addEventListener(tapEvent, this._onCaptureClick.bind(this), true);
+    document.addEventListener('focus', this._onCaptureFocus.bind(this), true);
+    document.addEventListener('keydown', this._onCaptureKeyDown.bind(this), true);
   };
 
   Polymer.IronOverlayManagerClass.prototype = {
@@ -67,52 +64,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     /**
      * The deepest active element.
-     * @type {Element|undefined} activeElement the active element
+     * @type {Element} activeElement the active element
      */
     get deepActiveElement() {
-      var active = document.activeElement;
       // document.activeElement can be null
       // https://developer.mozilla.org/en-US/docs/Web/API/Document/activeElement
-      while (active && active.root && Polymer.dom(active.root).activeElement) {
+      // In case of null, default it to document.body.
+      var active = document.activeElement || document.body;
+      while (active.root && Polymer.dom(active.root).activeElement) {
         active = Polymer.dom(active.root).activeElement;
       }
       return active;
-    },
-
-    /**
-     * If a node is contained in an overlay.
-     * @param {Element=} node
-     * @return {boolean}
-     * @private
-     */
-    _isChildOfOverlay: function(node) {
-      while (node && node !== document.body) {
-        // Use logical parentNode, or native ShadowRoot host.
-        node = Polymer.dom(node).parentNode || node.host;
-        // Check if it is an overlay.
-        if (node && node.behaviors && node.behaviors.indexOf(Polymer.IronOverlayBehaviorImpl) !== -1) {
-          return true;
-        }
-      }
-      return false;
-    },
-
-    /**
-     * @param {Element} overlay
-     * @param {number} aboveZ
-     * @private
-     */
-    _applyOverlayZ: function(overlay, aboveZ) {
-      this._setZ(overlay, aboveZ + 2);
-    },
-
-    /**
-     * @param {Element} element
-     * @param {number|string} z
-     * @private
-     */
-    _setZ: function(element, z) {
-      element.style.zIndex = z;
     },
 
     /**
@@ -127,11 +89,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         this._applyOverlayZ(overlay, minimumZ);
       }
       var element = this.deepActiveElement;
-      // If already in other overlay, don't reset focus there.
-      if (this._isChildOfOverlay(element)) {
-        element = null;
-      }
-      this._lastFocusedNodes.push(element);
+      overlay.restoreFocusNode = this._overlayParent(element) ? null : element;
     },
 
     /**
@@ -143,31 +101,30 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         this._overlays.splice(i, 1);
         this._setZ(overlay, '');
 
-        var node = this._lastFocusedNodes[i];
-        // Focus only if still contained in document.body
-        if (overlay.restoreFocusOnClose && node && Polymer.dom(document.body).deepContains(node)) {
+        var node = overlay.restoreFocusOnClose ? overlay.restoreFocusNode : null;
+        overlay.restoreFocusNode = null;
+        // Focus back only if still contained in document.body
+        if (node && Polymer.dom(document.body).deepContains(node)) {
           node.focus();
         }
-        this._lastFocusedNodes.splice(i, 1);
       }
     },
 
     /**
-     * @return {Element|undefined} overlay The current overlay.
+     * Returns the current overlay.
+     * @return {Element|undefined}
      */
     currentOverlay: function() {
       var i = this._overlays.length - 1;
-      while (this._overlays[i] && !this._overlays[i].opened) {
-        --i;
-      }
       return this._overlays[i];
     },
 
     /**
-     * @return {number} zIndex the current overlay z-index.
+     * Returns the current overlay z-index.
+     * @return {number}
      */
     currentOverlayZ: function() {
-      return this._getOverlayZ(this.currentOverlay());
+      return this._getZ(this.currentOverlay());
     },
 
     /**
@@ -198,38 +155,38 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      * @param {Element} overlay The overlay that updated its withBackdrop.
      */
     trackBackdrop: function(overlay) {
-      var index = this._backdrops.indexOf(overlay);
-      if (overlay.opened && overlay.withBackdrop) {
-        // no duplicates
-        if (index === -1) {
-          this._backdrops.push(overlay);
-        }
-      } else if (index >= 0) {
-        this._backdrops.splice(index, 1);
-      }
+      this.backdropElement.style.zIndex = this.backdropZ();
     },
 
     /**
-     * @return {Array<Element>} backdrops
+     * @return {Array<Element>}
      */
     getBackdrops: function() {
-      return this._backdrops;
+      var backdrops = [];
+      for (var i = 0; i < this._overlays.length; i++) {
+        if (this._overlays[i].withBackdrop) {
+          backdrops.push(this._overlays[i]);
+        }
+      }
+      return backdrops;
     },
 
     /**
-     * @return {number} index The z-index for the backdrop.
+     * Returns the z-index for the backdrop.
+     * @return {number}
      */
     backdropZ: function() {
-      return this._getOverlayZ(this._overlayWithBackdrop()) - 1;
+      return this._getZ(this._overlayWithBackdrop()) - 1;
     },
 
     /**
-     * @return {Element|undefined} overlay The first opened overlay that has a backdrop.
+     * Returns the first opened overlay that has a backdrop.
+     * @return {Element|undefined}
      * @private
      */
     _overlayWithBackdrop: function() {
       for (var i = 0; i < this._overlays.length; i++) {
-        if (this._overlays[i].opened && this._overlays[i].withBackdrop) {
+        if (this._overlays[i].withBackdrop) {
           return this._overlays[i];
         }
       }
@@ -240,7 +197,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      * @param {Element=} overlay
      * @private
      */
-    _getOverlayZ: function(overlay) {
+    _getZ: function(overlay) {
       var z = this._minimumZ;
       if (overlay) {
         var z1 = Number(window.getComputedStyle(overlay).zIndex);
@@ -251,6 +208,84 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         }
       }
       return z;
+    },
+
+    /**
+     * @param {Element} element
+     * @param {number|string} z
+     * @private
+     */
+    _setZ: function(element, z) {
+      element.style.zIndex = z;
+    },
+
+    /**
+     * @param {Element} overlay
+     * @param {number} aboveZ
+     * @private
+     */
+    _applyOverlayZ: function(overlay, aboveZ) {
+      this._setZ(overlay, aboveZ + 2);
+    },
+
+    /**
+     * Returns the overlay containing the provided node. If the node is an overlay,
+     * it returns the node.
+     * @param {Element=} node
+     * @return {Element|undefined}
+     * @private
+     */
+    _overlayParent: function(node) {
+      while (node && node !== document.body) {
+        // Check if it is an overlay.
+        if (node._manager === this) {
+          return node;
+        }
+        // Use logical parentNode, or native ShadowRoot host.
+        node = Polymer.dom(node).parentNode || node.host;
+      }
+    },
+
+    /**
+     * Ensures the click event is delegated to the right overlay.
+     * @param {!Event} event
+     * @private
+     */
+    _onCaptureClick: function(event) {
+      var overlay = /** @type {?} */ (this.currentOverlay());
+      // Check if clicked outside of any overlay.
+      var target = Polymer.dom(event).rootTarget;
+      if (overlay && this._overlayParent(target) !== overlay) {
+        overlay._onCaptureClick(event);
+      }
+    },
+
+    /**
+     * Ensures the focus event is delegated to the right overlay.
+     * @param {!Event} event
+     * @private
+     */
+    _onCaptureFocus: function(event) {
+      var overlay = /** @type {?} */ (this.currentOverlay());
+      if (overlay) {
+        overlay._onCaptureFocus(event);
+      }
+    },
+
+    /**
+     * Ensures TAB and ESC keyboard events are delegated to the right overlay.
+     * @param {!Event} event
+     * @private
+     */
+    _onCaptureKeyDown: function(event) {
+      var overlay = /** @type {?} */ (this.currentOverlay());
+      if (overlay) {
+        if (Polymer.IronA11yKeysBehavior.keyboardEventMatchesKeys(event, 'esc')) {
+          overlay._onCaptureEsc(event);
+        } else if (Polymer.IronA11yKeysBehavior.keyboardEventMatchesKeys(event, 'tab')) {
+          overlay._onCaptureTab(event);
+        }
+      }
     }
   };
 

--- a/test/iron-overlay-behavior.html
+++ b/test/iron-overlay-behavior.html
@@ -330,6 +330,38 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       });
 
+      suite('keyboard event listener', function() {
+        var overlay;
+
+        var preventKeyDown = function(event) {
+          event.preventDefault();
+          event.stopPropagation();
+        }
+
+        suiteSetup(function() {
+          // Worst case scenario: listener with useCapture = true that prevents & stops propagation
+          // added before the overlay is initialized.
+          document.addEventListener('keydown', preventKeyDown, true);
+        });
+
+        setup(function() {
+          overlay = fixture('basic');
+        });
+
+        suiteTeardown(function() {
+          document.removeEventListener('keydown', preventKeyDown, true);
+        });
+
+        test('cancel an overlay with esc key even if event is prevented by other listeners', function(done) {
+          runAfterOpen(overlay, function() {
+            overlay.addEventListener('iron-overlay-canceled', function(event) {
+              done();
+            });
+            MockInteractions.pressAndReleaseKeyOn(document, 27);
+          });
+        });
+      });
+
       suite('opened overlay', function() {
         var overlay;
 
@@ -809,6 +841,20 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
               var bgStyleZ = parseInt(window.getComputedStyle(overlay1.backdropElement).zIndex, 10);
               assert.isTrue(style1Z > styleZ, 'overlay2 has higher z-index than overlay1');
               assert.isTrue(styleZ > bgStyleZ, 'overlay1 has higher z-index than backdrop');
+              done();
+            });
+          });
+        });
+
+        test('click events handled only by top overlay', function(done) {
+          var btn = document.createElement('button');
+          btn.addEventListener('tap', overlay2.close.bind(overlay2));
+          Polymer.dom(overlay2).appendChild(btn);
+          runAfterOpen(overlay1, function() {
+            runAfterOpen(overlay2, function() {
+              MockInteractions.tap(btn);
+              assert.isFalse(overlay2.opened, 'overlay2 closed');
+              assert.isTrue(overlay1.opened, 'overlay1 still opened');
               done();
             });
           });


### PR DESCRIPTION
Fixes #109, fixes #117 by handling click and focus listeners on `iron-overlay-manager`.

Previously, each overlay would have these listeners, and these were toggled a tick after `_onOpenedChanged` (to avoid the triggering click event to close them). This was cumbersome because we'd have a lot of listeners, and each overlay would check if it is the `currentOverlay`.

Now, `iron-overlay-manager` will always listen for `click` and `focus`, and delegates the actions only to the current/top overlay (does also some other safety checks). To avoid the immediate closing, we delay the setting of `currentOverlay` for a tick. This fixes also #117.

Finally, we synchronously update the `_overlays`, so that we are sure the array will always contain opened overlays. This allowed to remove `_backdrops`.

`keydown` listener moved to the Manager as well, in order to use `useCapture` and have less listeners.


Some examples:
- [2 nested overlays](http://jsbin.com/xuguxa/1/edit?html,output) - [with the fix](http://jsbin.com/savivac/1/edit?html,output)
- [2 overlays](http://jsbin.com/zipugig/2/edit?html,output) - [with the fix](http://jsbin.com/vebinu/12/edit?html,output)
- [2 dropdowns](http://jsbin.com/reqayid/3/edit?html,output) - [with the fix](http://jsbin.com/dafaho/3/edit?html,output)