### PR TITLE
Update iron-overlay-behavior.html

### DIFF
--- a/iron-overlay-behavior.html
+++ b/iron-overlay-behavior.html
@@ -161,7 +161,12 @@ context. You should place this element as a child of `<body>` whenever possible.
        */
       _focusedChild: {
         type: Object
-      }
+      },
+      /**
+       * Cancel auto refitting when overlay was resized
+       * @type Boolean 
+       */
+      cancelAutoRefit: Boolean
 
     },
 
@@ -514,6 +519,7 @@ context. You should place this element as a child of `<body>` whenever possible.
 
     _onIronResize: function() {
       if (this.opened) {
+        if(this.cancelAutoRefit) return;
         this.refit();
       }
     },


### PR DESCRIPTION
Sometimes auto refitting could be annoying, especially if overlay contains some dynamic animated elements like dropdown or context menu.