### PR TITLE
use requestAnimationFrame for non-blocking animations

### DIFF
--- a/iron-overlay-behavior.html
+++ b/iron-overlay-behavior.html
@@ -226,6 +226,10 @@ context. You should place this element as a child of `<body>` whenever possible.
       this.__shouldRemoveTabIndex = false;
       // Used for wrapping the focus on TAB / Shift+TAB.
       this.__firstFocusableNode = this.__lastFocusableNode = null;
+      // Used for requestAnimationFrame when opened changes.
+      this.__openChangedAsync = null;
+      // Used for requestAnimationFrame when iron-resize is fired.
+      this.__onIronResizeAsync = null;
       this._ensureSetup();
     },
 
@@ -313,23 +317,19 @@ context. You should place this element as a child of `<body>` whenever possible.
       if (this.opened) {
         this._prepareRenderOpened();
       }
-      if (this._openChangedAsync) {
-        this.cancelAsync(this._openChangedAsync);
+
+      // requestAnimationFrame for non-blocking rendering
+      if (this.__openChangedAsync) {
+        cancelAnimationFrame(this.__openChangedAsync);
       }
-      // Async here to allow overlay layer to become visible.
-      this._openChangedAsync = this.async(function() {
-        // overlay becomes visible here
-        this.style.display = '';
-        // Force layout to ensure transition will go. Set offsetWidth to itself
-        // so that compilers won't remove it.
-        this.offsetWidth = this.offsetWidth;
+      this.__openChangedAsync = requestAnimationFrame(function() {
+        this.__openChangedAsync = null;
         if (this.opened) {
           this._renderOpened();
         } else {
           this._renderClosed();
         }
-        this._openChangedAsync = null;
-      });
+      }.bind(this));
     },
 
     _canceledChanged: function() {
@@ -425,6 +425,8 @@ context. You should place this element as a child of `<body>` whenever possible.
     _finishRenderClosed: function() {
       // Hide the overlay and remove the backdrop.
       this.style.display = 'none';
+      // Reset z-index only at the end of the animation.
+      this.style.zIndex = '';
 
       this._applyFocus();
 
@@ -440,12 +442,8 @@ context. You should place this element as a child of `<body>` whenever possible.
     },
 
     _finishPositioning: function() {
-      this.style.display = 'none';
-      this.style.transform = this.style.webkitTransform = '';
-      // Force layout layout to avoid application of transform.
-      // Set offsetWidth to itself so that compilers won't remove it.
-      this.offsetWidth = this.offsetWidth;
       this.style.transition = this.style.webkitTransition = '';
+      this.style.transform = this.style.webkitTransform = '';
     },
 
     /**
@@ -528,12 +526,15 @@ context. You should place this element as a child of `<body>` whenever possible.
      * @protected
      */
     _onIronResize: function() {
-      if (this.__isAnimating) {
-        return;
+      if (this.__onIronResizeAsync) {
+        cancelAnimationFrame(this.__onIronResizeAsync);
+        this.__onIronResizeAsync = null;
       }
-
-      if (this.opened) {
-        this.refit();
+      if (this.opened && !this.__isAnimating) {
+        this.__onIronResizeAsync = requestAnimationFrame(function() {
+          this.__onIronResizeAsync = null;
+          this.refit();
+        }.bind(this));
       }
     },
 

--- a/iron-overlay-manager.html
+++ b/iron-overlay-manager.html
@@ -146,7 +146,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         return;
       }
       this._overlays.splice(i, 1);
-      this._setZ(overlay, '');
 
       var node = overlay.restoreFocusOnClose ? overlay.restoreFocusNode : null;
       overlay.restoreFocusNode = null;
@@ -246,7 +245,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     _getZ: function(overlay) {
       var z = this._minimumZ;
       if (overlay) {
-        var z1 = Number(window.getComputedStyle(overlay).zIndex);
+        var z1 = Number(overlay.style.zIndex || window.getComputedStyle(overlay).zIndex);
         // Check if is a number
         // Number.isNaN not supported in IE 10+
         if (z1 === z1) {

--- a/test/iron-overlay-behavior.html
+++ b/test/iron-overlay-behavior.html
@@ -128,9 +128,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     <script>
       function runAfterOpen(overlay, callback) {
-        overlay.addEventListener('iron-overlay-opened', function() {
-          Polymer.Base.async(callback, 1);
-        });
+        overlay.addEventListener('iron-overlay-opened', callback);
         overlay.open();
       }
 
@@ -168,10 +166,34 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           overlay.opened = true;
         });
 
-        test('closed overlay does not refit on iron-resize', function() {
+        test('open() refits overlay only once', function(done) {
+          var spy = sinon.spy(overlay, 'refit');
+          runAfterOpen(overlay, function() {
+            assert.equal(spy.callCount, 1, 'overlay did refit only once');
+            done();
+          });
+        });
+
+        test('open overlay refits on iron-resize', function(done) {
+          runAfterOpen(overlay, function() {
+            var spy = sinon.spy(overlay, 'refit');
+            overlay.fire('iron-resize');
+            Polymer.dom.flush();
+            requestAnimationFrame(function() {
+              assert.isTrue(spy.called, 'overlay did refit');
+              done();
+            });
+          });
+        });
+
+        test('closed overlay does not refit on iron-resize', function(done) {
           var spy = sinon.spy(overlay, 'refit');
           overlay.fire('iron-resize');
-          assert.isFalse(spy.called, 'overlay should not refit');
+          Polymer.dom.flush();
+          requestAnimationFrame(function() {
+            assert.isFalse(spy.called, 'overlay should not refit');
+            done();
+          });
         });
 
         test('open() triggers iron-resize', function(done) {
@@ -395,18 +417,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             done();
           });
         });
-
-        test('open overlay refits on iron-resize', function(done) {
-          var spy = sinon.spy(overlay, 'refit');
-          // At this point, overlay is still opening.
-          overlay.fire('iron-resize');
-          assert.isFalse(spy.called, 'overlay did not refit while animating');
-          overlay.addEventListener('iron-overlay-opened', function() {
-            overlay.fire('iron-resize');
-            assert.isTrue(spy.called, 'overlay did refit');
-            done();
-          });
-        });
       });
 
       suite('focus handling', function() {
@@ -503,17 +513,20 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           overlay.withBackdrop = true;
           var focusableNodes = overlay._focusableNodes;
           runAfterOpen(overlay, function() {
-            // Go to last element.
-            MockInteractions.focus(focusableNodes[focusableNodes.length-1]);
-            // Simulate TAB & focus out of overlay.
-            MockInteractions.pressAndReleaseKeyOn(document, 9);
-            MockInteractions.focus(document.body);
-            assert.equal(focusableNodes[0], document.activeElement, 'focus wrapped to first focusable');
-            // Simulate Shift+TAB & focus out of overlay.
-            MockInteractions.pressAndReleaseKeyOn(document, 9, ['shift']);
-            MockInteractions.focus(document.body);
-            assert.equal(focusableNodes[focusableNodes.length-1], document.activeElement, 'focus wrapped to last focusable');
-            done();
+            Polymer.Base.async(function() {
+              // Go to last element.
+              MockInteractions.focus(focusableNodes[focusableNodes.length-1]);
+              // Simulate TAB & focus out of overlay.
+              MockInteractions.pressAndReleaseKeyOn(document, 9);
+              MockInteractions.focus(document.body);
+
+              assert.equal(focusableNodes[0], document.activeElement, 'focus wrapped to first focusable');
+              // Simulate Shift+TAB & focus out of overlay.
+              MockInteractions.pressAndReleaseKeyOn(document, 9, ['shift']);
+              MockInteractions.focus(document.body);
+              assert.equal(focusableNodes[focusableNodes.length-1], document.activeElement, 'focus wrapped to last focusable');
+              done();
+            }, 1);
           });
         });
 
@@ -521,17 +534,19 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           overlayWithTabIndex.withBackdrop = true;
           var focusableNodes = overlayWithTabIndex._focusableNodes;
           runAfterOpen(overlayWithTabIndex, function() {
-            // Go to last element.
-            MockInteractions.focus(focusableNodes[focusableNodes.length-1]);
-            // Simulate TAB & focus out of overlay.
-            MockInteractions.pressAndReleaseKeyOn(document, 9);
-            MockInteractions.focus(document.body);
-            assert.equal(focusableNodes[0], document.activeElement, 'focus wrapped to first focusable');
-            // Simulate Shift+TAB & focus out of overlay.
-            MockInteractions.pressAndReleaseKeyOn(document, 9, ['shift']);
-            MockInteractions.focus(document.body);
-            assert.equal(focusableNodes[focusableNodes.length-1], document.activeElement, 'focus wrapped to last focusable');
-            done();
+            Polymer.Base.async(function() {
+              // Go to last element.
+              MockInteractions.focus(focusableNodes[focusableNodes.length-1]);
+              // Simulate TAB & focus out of overlay.
+              MockInteractions.pressAndReleaseKeyOn(document, 9);
+              MockInteractions.focus(document.body);
+              assert.equal(focusableNodes[0], document.activeElement, 'focus wrapped to first focusable');
+              // Simulate Shift+TAB & focus out of overlay.
+              MockInteractions.pressAndReleaseKeyOn(document, 9, ['shift']);
+              MockInteractions.focus(document.body);
+              assert.equal(focusableNodes[focusableNodes.length-1], document.activeElement, 'focus wrapped to last focusable');
+              done();
+            }, 1);
           });
         });
 
@@ -889,7 +904,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           Polymer.Base.async(function() {
             assert.lengthOf(document.querySelectorAll('iron-overlay-backdrop'), 0, 'backdrop element removed from the DOM');
             done();
-          }, 1);
+          }, 100);
         });
 
         test('newest overlay appear on top', function(done) {


### PR DESCRIPTION
Fixes #99, fixes #135 by using `requestAnimationFrame` instead of `async`. 
Also, removed unnecessary setting of `display: ''` followed by `display: none`, and then again `display: ''`. It is enough to just make the overlay visible, calculate its size, and then `requestAnimationFrame` will cause the relayout. 
Tested the patch on `paper-dialog` with animations, it doesn't flash in any of the tested browsers (chrome, firefox, safari).

Also, reset `z-index` only on `_finishRenderClosed`, so that the overlay is on top during its animation, and goes "behind" only when is invisible. This makes the dialog animations much better because a dialog with backdrop doesn't suddenly go back the backdrop when closed.

#135 gets fixed because we don't need to set `offsetWidth` to itself anymore.