### PR TITLE
always-on-top implementation

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -100,6 +100,23 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </template>
   </demo-snippet>
 
+  <h3>Use <code>always-on-top</code> to keep the overlay on top of others.</h3>
+  <demo-snippet>
+    <template>
+      <button onclick="onTop.open()">Open always-on-top</button>
+      <simple-overlay id="onTop" always-on-top tabindex=-1>
+        <h2>Always on top</h2>
+        <button onclick="backdrop2.open()">Open with backdrop</button>
+        <button onclick="onTop.close()">Close this</button>
+      </simple-overlay>
+      <simple-overlay id="backdrop2" with-backdrop tabindex=-1>
+        <h2>With backdrop</h2>
+        <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+        <button onclick="backdrop2.close()">Close</button>
+      </simple-overlay>
+    </template>
+  </demo-snippet>
+
   <h3>An element with <code>IronOverlayBehavior</code> can be scrollable or contain scrollable content.</h3>
   <demo-snippet>
     <template>

--- a/iron-overlay-behavior.html
+++ b/iron-overlay-behavior.html
@@ -127,6 +127,13 @@ context. You should place this element as a child of `<body>` whenever possible.
       },
 
       /**
+       * Set to true to keep overlay always on top.
+       */
+      alwaysOnTop: {
+        type: Boolean
+      },
+
+      /**
        * Shortcut to access to the overlay manager.
        * @private
        * @type {Polymer.IronOverlayManagerClass}

--- a/iron-overlay-manager.html
+++ b/iron-overlay-manager.html
@@ -85,8 +85,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     _bringOverlayAtIndexToFront: function(i) {
       var overlay = this._overlays[i];
       var lastI = this._overlays.length - 1;
+      // Ensure always-on-top overlay stays on top.
+      if (!overlay.alwaysOnTop && this._overlays[lastI].alwaysOnTop) {
+        lastI--;
+      }
       // If already the top element, return.
-      if (!overlay || i === lastI) {
+      if (!overlay || i >= lastI) {
         return;
       }
       // Update z-index to be on top.
@@ -119,6 +123,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     /**
      * Tracks overlays for z-index and focus management.
+     * Ensures the last added overlay with always-on-top remains on top.
      * @param {Element} overlay
      */
     addOverlay: function(overlay) {
@@ -127,12 +132,28 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         this._bringOverlayAtIndexToFront(i);
         return;
       }
-      var minimumZ = Math.max(this.currentOverlayZ(), this._minimumZ);
-      this._overlays.push(overlay);
-      var newZ = this.currentOverlayZ();
+      var insertionIndex = this._overlays.length;
+      var currentOverlay = this._overlays[insertionIndex - 1];
+      var minimumZ = Math.max(this._getZ(currentOverlay), this._minimumZ);
+      var newZ = this._getZ(overlay);
+
+      // Ensure always-on-top overlay stays on top.
+      if (currentOverlay && currentOverlay.alwaysOnTop && !overlay.alwaysOnTop) {
+        // This bumps the z-index of +2.
+        this._applyOverlayZ(currentOverlay, minimumZ);
+        insertionIndex--;
+        // Update minimumZ to match previous overlay's z-index.
+        var previousOverlay = this._overlays[insertionIndex - 1];
+        minimumZ = Math.max(this._getZ(previousOverlay), this._minimumZ);
+      }
+
+      // Update z-index and insert overlay.
       if (newZ <= minimumZ) {
         this._applyOverlayZ(overlay, minimumZ);
       }
+      this._overlays.splice(insertionIndex, 0, overlay);
+
+      // Get focused node.
       var element = this.deepActiveElement;
       overlay.restoreFocusNode = this._overlayParent(element) ? null : element;
     },

--- a/test/iron-overlay-behavior.html
+++ b/test/iron-overlay-behavior.html
@@ -949,6 +949,57 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             }, 1);
           });
         });
+        
+      });
+
+      suite('always-on-top', function() {
+        var overlay1, overlay2;
+
+        setup(function() {
+          var f = fixture('multiple');
+          overlay1 = f[0];
+          overlay2 = f[1];
+          overlay1.alwaysOnTop = true;
+        });
+
+        test('stays on top', function(done) {
+          runAfterOpen(overlay1, function() {
+            runAfterOpen(overlay2, function() {
+              var zIndex1 = parseInt(window.getComputedStyle(overlay1).zIndex, 10);
+              var zIndex2 = parseInt(window.getComputedStyle(overlay2).zIndex, 10);
+              assert.isAbove(zIndex1, zIndex2, 'overlay1 on top');
+              assert.equal(Polymer.IronOverlayManager.currentOverlay(), overlay1, 'currentOverlay ok');
+              done();
+            });
+          });
+        });
+
+        test('stays on top also if another overlay is with-backdrop', function(done) {
+          overlay2.withBackdrop = true;
+          runAfterOpen(overlay1, function() {
+            runAfterOpen(overlay2, function() {
+              var zIndex1 = parseInt(window.getComputedStyle(overlay1).zIndex, 10);
+              var zIndex2 = parseInt(window.getComputedStyle(overlay2).zIndex, 10);
+              assert.isAbove(zIndex1, zIndex2, 'overlay1 on top');
+              assert.equal(Polymer.IronOverlayManager.currentOverlay(), overlay1, 'currentOverlay ok');
+              done();
+            });
+          });
+        });
+
+        test('last overlay with always-on-top wins', function(done) {
+          overlay2.alwaysOnTop = true;
+          runAfterOpen(overlay1, function() {
+            runAfterOpen(overlay2, function() {
+              var zIndex1 = parseInt(window.getComputedStyle(overlay1).zIndex, 10);
+              var zIndex2 = parseInt(window.getComputedStyle(overlay2).zIndex, 10);
+              assert.isAbove(zIndex2, zIndex1, 'overlay2 on top');
+              assert.equal(Polymer.IronOverlayManager.currentOverlay(), overlay2, 'currentOverlay ok');
+              done();
+            });
+          });
+        });
+
       });
 
       suite('a11y', function() {
@@ -962,7 +1013,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           assert.equal(overlay.getAttribute('aria-hidden'), 'true', 'overlay has aria-hidden="true"');
         });
 
-      })
+      });
     </script>
 
   </body>


### PR DESCRIPTION
Fixes #3 by implementing `always-on-top` property.
- the overlay with `always-on-top` should match the `Polymer.IronOverlayManager.currentOverlay()` even if other overlays are opened after it
- if there is more than one overlay with `always-on-top`, the last one to be opened wins (is on top)
- `with-backdrop` doesn't affect `always-on-top`