### PR TITLE
Use parseInt instead of Number to handle empty string as NaN

### DIFF
--- a/iron-overlay-manager.html
+++ b/iron-overlay-manager.html
@@ -243,7 +243,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     _getOverlayZ: function(overlay) {
       var z = this._minimumZ;
       if (overlay) {
-        var z1 = Number(window.getComputedStyle(overlay).zIndex);
+        var z1 = parseInt(window.getComputedStyle(overlay).zIndex);
         // Check if is a number
         // Number.isNaN not supported in IE 10+
         if (z1 === z1) {


### PR DESCRIPTION
Fixes #127 since Number("") evaluates to 0 whereas parseInt("") evaluates to NaN which should be the expected behavior here.