### PR TITLE
avoid duplicates when adding overlays

### DIFF
--- a/iron-overlay-behavior.html
+++ b/iron-overlay-behavior.html
@@ -306,16 +306,13 @@ context. You should place this element as a child of `<body>` whenever possible.
         return;
       }
 
+      this._manager.addOrRemoveOverlay(this);
+
       this.__isAnimating = true;
 
       if (this.opened) {
         this._prepareRenderOpened();
-      } else {
-        this._manager.removeOverlay(this);
       }
-
-      this._manager.trackBackdrop(this);
-
       if (this._openChangedAsync) {
         this.cancelAsync(this._openChangedAsync);
       }
@@ -350,7 +347,7 @@ context. You should place this element as a child of `<body>` whenever possible.
         this.__shouldRemoveTabIndex = false;
       }
       if (this.opened) {
-        this._manager.trackBackdrop(this);
+        this._manager.trackBackdrop();
         if (this.withBackdrop) {
           this.backdropElement.prepare();
           // Give time to be added to document.
@@ -368,8 +365,6 @@ context. You should place this element as a child of `<body>` whenever possible.
      * @protected
      */
     _prepareRenderOpened: function() {
-
-      this._manager.addOverlay(this);
 
       // Needed to calculate the size of the overlay so that transitions on its size
       // will have the correct starting points.

--- a/iron-overlay-manager.html
+++ b/iron-overlay-manager.html
@@ -78,10 +78,55 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     },
 
     /**
+     * Brings the overlay at the specified index to the front.
+     * @param {number} i
+     * @private
+     */
+    _bringOverlayAtIndexToFront: function(i) {
+      var overlay = this._overlays[i];
+      var lastI = this._overlays.length - 1;
+      // If already the top element, return.
+      if (!overlay || i === lastI) {
+        return;
+      }
+      // Update z-index to be on top.
+      var minimumZ = Math.max(this.currentOverlayZ(), this._minimumZ);
+      if (this._getZ(overlay) <= minimumZ) {
+        this._applyOverlayZ(overlay, minimumZ);
+      }
+
+      // Shift other overlays behind the new on top.
+      while (i < lastI) {
+        this._overlays[i] = this._overlays[i + 1];
+        i++;
+      }
+      this._overlays[lastI] = overlay;
+    },
+
+    /**
+     * Adds the overlay and updates its z-index if it's opened, or removes it if it's closed.
+     * Also updates the backdrop z-index.
+     * @param {Element} overlay
+     */
+    addOrRemoveOverlay: function(overlay) {
+      if (overlay.opened) {
+        this.addOverlay(overlay);
+      } else {
+        this.removeOverlay(overlay);
+      }
+      this.trackBackdrop();
+    },
+
+    /**
      * Tracks overlays for z-index and focus management.
      * @param {Element} overlay
      */
     addOverlay: function(overlay) {
+      var i = this._overlays.indexOf(overlay);
+      if (i >= 0) {
+        this._bringOverlayAtIndexToFront(i);
+        return;
+      }
       var minimumZ = Math.max(this.currentOverlayZ(), this._minimumZ);
       this._overlays.push(overlay);
       var newZ = this.currentOverlayZ();
@@ -97,16 +142,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      */
     removeOverlay: function(overlay) {
       var i = this._overlays.indexOf(overlay);
-      if (i >= 0) {
-        this._overlays.splice(i, 1);
-        this._setZ(overlay, '');
+      if (i === -1) {
+        return;
+      }
+      this._overlays.splice(i, 1);
+      this._setZ(overlay, '');
 
-        var node = overlay.restoreFocusOnClose ? overlay.restoreFocusNode : null;
-        overlay.restoreFocusNode = null;
-        // Focus back only if still contained in document.body
-        if (node && Polymer.dom(document.body).deepContains(node)) {
-          node.focus();
-        }
+      var node = overlay.restoreFocusOnClose ? overlay.restoreFocusNode : null;
+      overlay.restoreFocusNode = null;
+      // Focus back only if still contained in document.body
+      if (node && Polymer.dom(document.body).deepContains(node)) {
+        node.focus();
       }
     },
 
@@ -152,9 +198,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     },
 
     /**
-     * @param {Element} overlay The overlay that updated its withBackdrop.
+     * Updates the backdrop z-index.
      */
-    trackBackdrop: function(overlay) {
+    trackBackdrop: function() {
       this.backdropElement.style.zIndex = this.backdropZ();
     },
 

--- a/test/iron-overlay-behavior.html
+++ b/test/iron-overlay-behavior.html
@@ -751,6 +751,55 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             done();
           })
         });
+
+      });
+
+      suite('Manager overlays in sync', function() {
+        var overlay1, overlay2;
+        var overlays;
+
+        setup(function() {
+          var f = fixture('multiple');
+          overlay1 = f[0];
+          overlay2 = f[1];
+          overlays = Polymer.IronOverlayManager._overlays;
+        });
+
+        test('no duplicates after attached', function(done) {
+          overlay1 = document.createElement('test-overlay');
+          overlay1.addEventListener('iron-overlay-opened',function() {
+            assert.equal(overlays.length, 1, 'correct count after open and attached');
+            document.body.removeChild(overlay1);
+            done();
+          });
+          overlay1.opened = true;
+          assert.equal(overlays.length, 1, 'immediately updated');
+          document.body.appendChild(overlay1);
+        });
+
+        test('open twice handled', function() {
+          overlay1.open();
+          assert.equal(overlays.length, 1, '1 overlay after open');
+          overlay1.open();
+          assert.equal(overlays.length, 1, '1 overlay after second open');
+        });
+
+        test('close handled', function() {
+          overlay1.open();
+          overlay1.close();
+          assert.equal(overlays.length, 0, '0 overlays after close');
+        });
+
+        test('open/close brings overlay on top', function() {
+          overlay1.open();
+          overlay2.open();
+          assert.equal(overlays.indexOf(overlay1), 0, 'overlay1 at index 0');
+          assert.equal(overlays.indexOf(overlay2), 1, 'overlay2 at index 1');
+          overlay1.close();
+          overlay1.open();
+          assert.equal(overlays.indexOf(overlay1), 1, 'overlay1 moved at index 1');
+          assert.isAbove(parseInt(overlay1.style.zIndex), parseInt(overlay2.style.zIndex), 'overlay1 on top of overlay2');
+        });
       });
 
       suite('z-ordering', function() {


### PR DESCRIPTION
Fixes #129 by ensuring `_overlays` gets updated synchronously when an `overlay.opened` changes.

Added new method to the manager, `bringToFront` which is useful to bring an overlay on top; it accepts both numbers (more efficient) and elements (more ergonomic for the Polymer user) as input.