### PR TITLE
close backdrop on detached

### DIFF
--- a/iron-overlay-backdrop.html
+++ b/iron-overlay-backdrop.html
@@ -40,12 +40,14 @@ Custom property | Description | Default
       background-color: var(--iron-overlay-backdrop-background-color, #000);
       opacity: 0;
       transition: opacity 0.2s;
+      pointer-events: none;
 
       @apply(--iron-overlay-backdrop);
     }
 
     :host([opened]) {
       opacity: var(--iron-overlay-backdrop-opacity, 0.6);
+      pointer-events: auto;
 
       @apply(--iron-overlay-backdrop-opened);
     }

--- a/iron-overlay-behavior.html
+++ b/iron-overlay-behavior.html
@@ -270,8 +270,10 @@ context. You should place this element as a child of `<body>` whenever possible.
       Polymer.dom(this).unobserveNodes(this._observer);
       this._observer = null;
       this.opened = false;
-      this._manager.trackBackdrop(this);
-      this._manager.removeOverlay(this);
+      if (this.withBackdrop) {
+        // Allow user interactions right away.
+        this.backdropElement.close();
+      }
     },
 
     /**

--- a/test/iron-overlay-behavior.html
+++ b/test/iron-overlay-behavior.html
@@ -186,27 +186,23 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           });
         });
 
-        test('closed overlay does not trigger iron-resize when its content changes', function(done) {
+        test('closed overlay does not trigger iron-resize when its content changes', function() {
           // Ignore iron-resize triggered by window resize.
           var callCount = 0;
           window.addEventListener('resize', function() { callCount--; }, true);
           overlay.addEventListener('iron-resize', function() { callCount++; });
           Polymer.dom(overlay).appendChild(document.createElement('div'));
-          overlay.async(function() {
-            assert.equal(callCount, 0, 'iron-resize should not be called');
-            done();
-          }, 10);
+          Polymer.dom.flush();
+          assert.equal(callCount, 0, 'iron-resize should not be called');
         });
 
-        test('open overlay triggers iron-resize when its content changes', function(done) {
+        test('open overlay triggers iron-resize when its content changes', function() {
           runAfterOpen(overlay, function() {
             var spy = sinon.stub();
             overlay.addEventListener('iron-resize', spy);
             Polymer.dom(overlay).appendChild(document.createElement('div'));
-            overlay.async(function() {
-              assert.equal(spy.callCount, 1, 'iron-resize should be called once');
-              done();
-            }, 10);
+            Polymer.dom.flush();
+            assert.equal(spy.callCount, 1, 'iron-resize should be called once');
           });
         });
 
@@ -369,7 +365,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             done();
           });
         });
-
       });
 
       suite('focus handling', function() {
@@ -632,7 +627,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           runAfterOpen(overlay, function() {
             runAfterClose(overlay, function() {
               assert.isFalse(overlay.backdropElement.opened, 'backdrop is closed');
-              assert.isNull(overlay.backdropElement.parentNode, 'backdrop is removed from the DOM');
+              assert.isNotOk(overlay.backdropElement.parentNode, 'backdrop is removed from the DOM');
               assert.lengthOf(document.querySelectorAll('iron-overlay-backdrop'), 0, 'no backdrop elements on body');
               done();
             });
@@ -642,12 +637,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         test('backdrop is removed when the element is removed from DOM', function(done) {
           runAfterOpen(overlay, function() {
             Polymer.dom(overlay).parentNode.removeChild(overlay);
-            // Wait enough so detached is executed.
-            Polymer.Base.async(function() {
-              assert.isNull(overlay.backdropElement.parentNode, 'backdrop is removed from the DOM');
-              assert.lengthOf(document.querySelectorAll('iron-overlay-backdrop'), 0, 'no backdrop elements on body');
-              done();
-            }, 100);
+            // Ensure detached is executed.
+            Polymer.dom.flush();
+            assert.isFalse(overlay.backdropElement.opened, 'backdrop is closed');
+            assert.isNotOk(overlay.backdropElement.parentNode, 'backdrop is removed from the DOM');
+            assert.lengthOf(document.querySelectorAll('iron-overlay-backdrop'), 0, 'no backdrop elements on body');
+            assert.isNotOk(overlay._manager.currentOverlay(), 'currentOverlay ok');
+            done();
           });
         });
 
@@ -676,7 +672,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             done();
           });
         });
-
       });
 
       suite('multiple overlays', function() {


### PR DESCRIPTION
Fixes #132 by ensuring `backdropElement` is closed right away on overlay `detached`. Also, `iron-overlay-backdrop` will have `pointer-events: none` when `opened = false`. This allows user interactions while the backdrop is animating :tada: 