### PR TITLE
remove a11y-keys behavior from overlay-behavior. Update jsdoc for rootTarget usage

### DIFF
--- a/iron-overlay-behavior.html
+++ b/iron-overlay-behavior.html
@@ -559,7 +559,7 @@ context. You should place this element as a child of `<body>` whenever possible.
   };
 
   /** @polymerBehavior */
-  Polymer.IronOverlayBehavior = [Polymer.IronA11yKeysBehavior, Polymer.IronFitBehavior, Polymer.IronResizableBehavior, Polymer.IronOverlayBehaviorImpl];
+  Polymer.IronOverlayBehavior = [Polymer.IronFitBehavior, Polymer.IronResizableBehavior, Polymer.IronOverlayBehaviorImpl];
 
   /**
   * Fired after the `iron-overlay` opens.

--- a/iron-overlay-manager.html
+++ b/iron-overlay-manager.html
@@ -254,7 +254,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     _onCaptureClick: function(event) {
       var overlay = /** @type {?} */ (this.currentOverlay());
       // Check if clicked outside of any overlay.
-      var target = Polymer.dom(event).rootTarget;
+      var target = /** @type {Element} */ (Polymer.dom(event).rootTarget);
       if (overlay && this._overlayParent(target) !== overlay) {
         overlay._onCaptureClick(event);
       }


### PR DESCRIPTION
`iron-overlay-behavior` does not import `iron-a11y-keys-behavior` anymore, neither uses this behavior (key listeners were moved to `iron-overlay-manager`).
Updated jsdoc for how the `rootTarget` is meant to be used in manager's `_onCaptureClick`