### PR TITLE
make _openedChangedAsync a microtask

### DIFF
--- a/iron-overlay-behavior.html
+++ b/iron-overlay-behavior.html
@@ -329,7 +329,7 @@ context. You should place this element as a child of `<body>` whenever possible.
           this._renderClosed();
         }
         this._openChangedAsync = null;
-      }, 1);
+      });
     },
 
     _canceledChanged: function() {


### PR DESCRIPTION
The 1ms delay was previously needed for toggling listeners, but since they're now handled in the manager, `_openedChangedAsync` can return to be a micro-task.