### PR TITLE
use path to correctly handle composed tree

### DIFF
--- a/iron-overlay-manager.html
+++ b/iron-overlay-manager.html
@@ -293,15 +293,29 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     },
 
     /**
+     * Returns the deepest overlay in the path.
+     * @param {?Array<Element>} path
+     * @return {Element|undefined}
+     * @private
+     */
+    _overlayInPath: function(path) {
+      path = path || [];
+      for (var i = 0; i < path.length; i++) {
+        if (path[i]._manager === this) {
+          return path[i];
+        }
+      }
+    },
+
+    /**
      * Ensures the click event is delegated to the right overlay.
      * @param {!Event} event
      * @private
      */
     _onCaptureClick: function(event) {
       var overlay = /** @type {?} */ (this.currentOverlay());
-      // Check if clicked outside of any overlay.
-      var target = /** @type {Element} */ (Polymer.dom(event).rootTarget);
-      if (overlay && this._overlayParent(target) !== overlay) {
+      // Check if clicked outside of top overlay.
+      if (overlay && this._overlayInPath(Polymer.dom(event).path) !== overlay) {
         overlay._onCaptureClick(event);
       }
     },

--- a/test/iron-overlay-behavior.html
+++ b/test/iron-overlay-behavior.html
@@ -25,6 +25,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <link rel="import" href="test-overlay.html">
     <link rel="import" href="test-overlay2.html">
     <link rel="import" href="test-buttons.html">
+    <link rel="import" href="test-menu-button.html">
 
     <style is="custom-style">
       iron-overlay-backdrop {
@@ -110,6 +111,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         <test-overlay2 class="overlay-3">
           Other overlay 3
         </test-overlay2>
+      </template>
+    </test-fixture>
+
+    <test-fixture id="composed">
+      <template>
+        <test-menu-button>
+          Composed overlay
+          <button>Button</button>
+        </test-menu-button>
       </template>
     </test-fixture>
 
@@ -923,6 +933,22 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           });
         });
 
+      });
+
+      suite('overlay in composed tree', function() {
+        test('click on overlay content does not close it', function(done) {
+          var composed = fixture('composed');
+          // Opens overlay.
+          MockInteractions.tap(composed.$.trigger);
+          composed.$.dropdown.addEventListener('iron-overlay-opened', function() {
+            // Tap on button inside overlay.
+            MockInteractions.tap(Polymer.dom(composed).querySelector('button'));
+            Polymer.Base.async(function(){
+              assert.isTrue(composed.$.dropdown.opened, 'overlay still opened');
+              done();
+            }, 1);
+          });
+        });
       });
 
       suite('a11y', function() {

--- a/test/test-menu-button.html
+++ b/test/test-menu-button.html
@@ -1,0 +1,36 @@
+<!--
+@license
+Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+
+<link rel="import" href="../../polymer/polymer.html">
+<link rel="import" href="test-overlay.html">
+
+<dom-module id="test-menu-button">
+
+  <template>
+    <button id="trigger" on-click="toggle">Open</button>
+    <test-overlay id="dropdown">
+      <content></content>
+    </test-overlay>
+  </template>
+
+</dom-module>
+
+<script>
+
+(function() {
+  Polymer({
+    is: 'test-menu-button',
+    toggle: function() {
+      this.$.dropdown.toggle();
+    }
+  });
+})();
+
+</script>


### PR DESCRIPTION
Rather than traversing the parent tree starting from a node, we use `event.path` to have the composed tree, in order to safely recognize who's the deepest overlay in that tree.