### PR TITLE
Update jsdoc: Accept null & undefined

### DIFF
--- a/iron-overlay-manager.html
+++ b/iron-overlay-manager.html
@@ -294,7 +294,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     /**
      * Returns the deepest overlay in the path.
-     * @param {?Array<Element>} path
+     * @param {Array<Element>=} path
      * @return {Element|undefined}
      * @private
      */


### PR DESCRIPTION
Since `event.path` can be either `null` or `undefined`, accept these values as input by setting a default.