### PR TITLE
listen to touchstart or mousedown

### DIFF
--- a/iron-overlay-manager.html
+++ b/iron-overlay-manager.html
@@ -38,11 +38,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      */
     this._backdropElement = null;
 
-    // Enable document-wide tap recognizer.
-    Polymer.Gestures.add(document, 'tap', null);
-    // We should be using only 'tap', but this would be a breaking change.
-    var tapEvent = ('ontouchstart' in window) ? 'tap' : 'click';
-    document.addEventListener(tapEvent, this._onCaptureClick.bind(this), true);
+    // Listen to mousedown or touchstart to be sure to be the first to capture
+    // clicks outside the overlay.
+    var clickEvent = ('ontouchstart' in window) ? 'touchstart' : 'mousedown';
+    document.addEventListener(clickEvent, this._onCaptureClick.bind(this), true);
     document.addEventListener('focus', this._onCaptureFocus.bind(this), true);
     document.addEventListener('keydown', this._onCaptureKeyDown.bind(this), true);
   };

--- a/test/iron-overlay-behavior.html
+++ b/test/iron-overlay-behavior.html
@@ -127,6 +127,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <input id="focusInput" placeholder="focus input">
 
     <script>
+
+      HTMLImports.whenReady(function() {
+        // Enable document-wide tap recognizer.
+        Polymer.Gestures.add(document, 'tap', null);
+      });
+      
       function runAfterOpen(overlay, callback) {
         overlay.addEventListener('iron-overlay-opened', function() {
           Polymer.Base.async(callback, 1);
@@ -240,6 +246,21 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
               done();
             }, 10);
           });
+        });
+
+        test('open overlay on mousedown does not close it', function(done) {
+          var btn = document.createElement('button');
+          btn.addEventListener('mousedown', overlay.open.bind(overlay));
+          document.body.appendChild(btn);
+          // It triggers mousedown, mouseup, and click.
+          MockInteractions.tap(btn);
+          document.body.removeChild(btn);
+
+          assert.isTrue(overlay.opened, 'overlay opened');
+          overlay.async(function() {
+            assert.isTrue(overlay.opened, 'overlay is still open');
+            done();
+          }, 10);
         });
 
         test('clicking outside fires iron-overlay-canceled', function(done) {
@@ -950,7 +971,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             }, 1);
           });
         });
-        
+
       });
 
       suite('always-on-top', function() {


### PR DESCRIPTION
Fixes #147 by listening to `touchstart` (touch devices) or `mousedown` rather than `tap/click`.
As a consequence, gestures like dragging outside the dialog cause the dialog to cancel, which is nice for elements like `iron-dropdown` on cases where the user selects text outside the dropdown, causing the dropdown to close.