### PR TITLE
fix: bug with iron-overlay-backdrop when on-screen keyboard is shown

### DIFF
--- a/iron-overlay-backdrop.html
+++ b/iron-overlay-backdrop.html
@@ -35,8 +35,8 @@ Custom property | Description | Default
       position: fixed;
       top: 0;
       left: 0;
-      width: 100vw;
-      height: 100vh;
+      width: 100%;
+      height: 100%;
       background-color: var(--iron-overlay-backdrop-background-color, #000);
       opacity: 0;
       transition: opacity 0.2s;

--- a/test/index.html
+++ b/test/index.html
@@ -22,7 +22,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <script>
       WCT.loadSuites([
         'iron-overlay-behavior.html',
-        'iron-overlay-behavior.html?dom=shadow'
+        'iron-overlay-behavior.html?dom=shadow',
+        'iron-overlay-backdrop.html',
+		'iron-overlay-backdrop.html?dom=shadow',
       ]);
     </script>
 

--- a/test/index.html
+++ b/test/index.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html><!--
 @license
-Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
 This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
 The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
 The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
@@ -24,10 +24,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         'iron-overlay-behavior.html',
         'iron-overlay-behavior.html?dom=shadow',
         'iron-overlay-backdrop.html',
-		'iron-overlay-backdrop.html?dom=shadow',
+        'iron-overlay-backdrop.html?dom=shadow',
       ]);
     </script>
-
-  
 
 </body></html>

--- a/test/index.html
+++ b/test/index.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html><!--
 @license
-Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
 This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
 The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
 The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt

--- a/test/iron-overlay-backdrop.html
+++ b/test/iron-overlay-backdrop.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <!--
 @license
-Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
 This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
 The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
 The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt

--- a/test/iron-overlay-backdrop.html
+++ b/test/iron-overlay-backdrop.html
@@ -1,0 +1,89 @@
+@@ -0,0 +1,89 @@
+<!doctype html>
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<html>
+
+  <head>
+
+    <title>iron-overlay-backdrop tests</title>
+
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1, user-scalable=yes">
+
+    <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+    <script src="../../web-component-tester/browser.js"></script>
+    <link rel="import" href="../../iron-test-helpers/iron-test-helpers.html">
+    <link rel="import" href="test-overlay.html">
+  	<style>
+  		html,
+  	    body {
+  		  margin: 0;
+  		  width: 100%;
+  		  height: 100%;
+  		  min-width: 0;
+  		}
+  		.sizer {
+  			width: 4000px;
+  			height: 5000px;
+  		}
+  	</style>
+    <style is="custom-style">
+      iron-overlay-backdrop {
+        /* For quicker tests */
+        --iron-overlay-backdrop: {
+          transition: none;
+        }
+      }
+    </style>
+  </head>
+
+  <body>
+	  <div class="sizer"></div>
+    <test-fixture id="backdrop">
+      <template>
+        <test-overlay with-backdrop>
+          Overlay with backdrop
+        </test-overlay>
+      </template>
+    </test-fixture>
+
+    <script>
+      function runAfterOpen(overlay, callback) {
+        overlay.addEventListener('iron-overlay-opened', callback);
+        overlay.open();
+      }
+
+      suite('overlay with backdrop', function() {
+        var overlay;
+		
+        setup(function() {
+          overlay = fixture('backdrop');
+        });
+
+        test('backdrop size matches parent size', function(done) {
+          runAfterOpen(overlay, function() {
+            Polymer.Base.async(function() {
+      			  var backdrop = overlay.backdropElement;
+      			  var parent = backdrop.parentElement;
+      			  assert.strictEqual(backdrop.offsetWidth, parent.clientWidth, 'backdrop width matches parent width');
+      			  assert.strictEqual(backdrop.offsetHeight, parent.clientHeight, 'backdrop height matches parent height');
+              done();
+            }, 1);
+          });
+        });
+		
+      });
+    </script>
+
+  </body>
+
+</html>

--- a/test/iron-overlay-backdrop.html
+++ b/test/iron-overlay-backdrop.html
@@ -1,4 +1,3 @@
-@@ -0,0 +1,89 @@
 <!doctype html>
 <!--
 @license
@@ -11,7 +10,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 -->
 <html>
 
-  <head>
+<head>
 
     <title>iron-overlay-backdrop tests</title>
 
@@ -20,70 +19,76 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1, user-scalable=yes">
 
     <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+
     <script src="../../web-component-tester/browser.js"></script>
     <link rel="import" href="../../iron-test-helpers/iron-test-helpers.html">
     <link rel="import" href="test-overlay.html">
-  	<style>
-  		html,
-  	    body {
-  		  margin: 0;
-  		  width: 100%;
-  		  height: 100%;
-  		  min-width: 0;
-  		}
-  		.sizer {
-  			width: 4000px;
-  			height: 5000px;
-  		}
-  	</style>
+
+    <style>
+        html,
+        body {
+            margin: 0;
+            width: 100%;
+            height: 100%;
+            min-width: 0;
+        }
+        .sizer {
+            width: 4000px;
+            height: 5000px;
+        }
+    </style>
+
     <style is="custom-style">
-      iron-overlay-backdrop {
+        iron-overlay-backdrop {
         /* For quicker tests */
         --iron-overlay-backdrop: {
-          transition: none;
+             transition: none;
+         }
         }
-      }
     </style>
-  </head>
 
-  <body>
-	  <div class="sizer"></div>
-    <test-fixture id="backdrop">
-      <template>
-        <test-overlay with-backdrop>
-          Overlay with backdrop
+</head>
+
+<body>
+
+<div class="sizer"></div>
+
+<test-fixture id="basic">
+    <template>
+        <test-overlay>
+            Basic Overlay
         </test-overlay>
-      </template>
-    </test-fixture>
+    </template>
+</test-fixture>
 
-    <script>
-      function runAfterOpen(overlay, callback) {
+<script>
+    function runAfterOpen(overlay, callback) {
         overlay.addEventListener('iron-overlay-opened', callback);
         overlay.open();
-      }
+    }
 
-      suite('overlay with backdrop', function() {
+    suite('overlay with backdrop', function() {
         var overlay;
-		
+
         setup(function() {
-          overlay = fixture('backdrop');
+            overlay = fixture('backdrop');
         });
 
         test('backdrop size matches parent size', function(done) {
-          runAfterOpen(overlay, function() {
-            Polymer.Base.async(function() {
-      			  var backdrop = overlay.backdropElement;
-      			  var parent = backdrop.parentElement;
-      			  assert.strictEqual(backdrop.offsetWidth, parent.clientWidth, 'backdrop width matches parent width');
-      			  assert.strictEqual(backdrop.offsetHeight, parent.clientHeight, 'backdrop height matches parent height');
-              done();
-            }, 1);
-          });
+            runAfterOpen(overlay, function() {
+                Polymer.Base.async(function() {
+                    var backdrop = overlay.backdropElement;
+                    var parent = backdrop.parentElement;
+                    assert.strictEqual(backdrop.offsetWidth, parent.clientWidth, 'backdrop width matches parent width');
+                    assert.strictEqual(backdrop.offsetHeight, parent.clientHeight, 'backdrop height matches parent height');
+                    done();
+                }, 1);
+            });
         });
-		
-      });
-    </script>
 
-  </body>
+    });
+</script>
+
+</body>
 
 </html>

--- a/test/iron-overlay-backdrop.html
+++ b/test/iron-overlay-backdrop.html
@@ -53,10 +53,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <div class="sizer"></div>
 
-<test-fixture id="basic">
+<test-fixture id="backdrop">
     <template>
-        <test-overlay>
-            Basic Overlay
+        <test-overlay with-backdrop>
+            Overlay with backdrop
         </test-overlay>
     </template>
 </test-fixture>


### PR DESCRIPTION
Any reason why `vh` was used instead of `%`?
Should resolve issue #149