### PR TITLE
ensure reflow for smooth animations

### DIFF
--- a/iron-overlay-behavior.html
+++ b/iron-overlay-behavior.html
@@ -15,6 +15,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="iron-overlay-manager.html">
 
 <script>
+// IIFE to help scripts concatenation.
+(function() {
+'use strict';
 
 /**
 Use `Polymer.IronOverlayBehavior` to implement an element that can be hidden or shown, and displays
@@ -321,22 +324,22 @@ context. You should place this element as a child of `<body>` whenever possible.
 
       this.__isAnimating = true;
 
-      if (this.opened) {
-        this._prepareRenderOpened();
-      }
-
       // requestAnimationFrame for non-blocking rendering
       if (this.__openChangedAsync) {
         cancelAnimationFrame(this.__openChangedAsync);
       }
-      this.__openChangedAsync = requestAnimationFrame(function() {
-        this.__openChangedAsync = null;
-        if (this.opened) {
-          this._renderOpened();
-        } else {
-          this._renderClosed();
+      if (this.opened) {
+        if (this.withBackdrop) {
+          this.backdropElement.prepare();
         }
-      }.bind(this));
+        this.__openChangedAsync = requestAnimationFrame(function() {
+          this.__openChangedAsync = null;
+          this._prepareRenderOpened();
+          this._renderOpened();
+        }.bind(this));
+      } else {
+        this._renderClosed();
+      }
     },
 
     _canceledChanged: function() {
@@ -378,10 +381,6 @@ context. You should place this element as a child of `<body>` whenever possible.
       this._preparePositioning();
       this.refit();
       this._finishPositioning();
-
-      if (this.withBackdrop) {
-        this.backdropElement.prepare();
-      }
 
       // Safari will apply the focus to the autofocus element when displayed for the first time,
       // so we blur it. Later, _applyFocus will set the focus if necessary.
@@ -449,8 +448,18 @@ context. You should place this element as a child of `<body>` whenever possible.
     },
 
     _finishPositioning: function() {
+      // First, make it invisible & reactivate animations.
+      this.style.display = 'none';
+      // Force reflow before re-enabling animations so that they don't start.
+      // Set scrollTop to itself so that Closure Compiler doesn't remove this.
+      this.scrollTop = this.scrollTop;
       this.style.transition = this.style.webkitTransition = '';
       this.style.transform = this.style.webkitTransform = '';
+      // Now that animations are enabled, make it visible again
+      this.style.display = '';
+      // Force reflow, so that following animations are properly started.
+      // Set scrollTop to itself so that Closure Compiler doesn't remove this.
+      this.scrollTop = this.scrollTop;
     },
 
     /**
@@ -584,4 +593,5 @@ context. You should place this element as a child of `<body>` whenever possible.
   * @param {{canceled: (boolean|undefined)}} closingReason Contains `canceled` (whether the overlay was canceled).
   */
 
+})();
 </script>

--- a/test/iron-overlay-behavior.html
+++ b/test/iron-overlay-behavior.html
@@ -132,7 +132,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         // Enable document-wide tap recognizer.
         Polymer.Gestures.add(document, 'tap', null);
       });
-      
+
       function runAfterOpen(overlay, callback) {
         overlay.addEventListener('iron-overlay-opened', callback);
         overlay.open();
@@ -1034,6 +1034,23 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
               assert.equal(Polymer.IronOverlayManager.currentOverlay(), overlay2, 'currentOverlay ok');
               done();
             });
+          });
+        });
+
+      });
+
+      suite('animations', function() {
+
+        test('overlay animations correctly triggered', function(done) {
+          var overlay = fixture('basic');
+          overlay.animated = true;
+          overlay.open();
+          overlay.addEventListener('simple-overlay-open-animation-start', function() {
+            // Since animated overlay will transition center + 300px to center,
+            // we should not find the element at the center when the open animation starts.
+            var centerElement = document.elementFromPoint(window.innerWidth/2, window.innerHeight/2);
+            assert.notEqual(centerElement, overlay, 'overlay should not be centered already');
+            done();
           });
         });
 

--- a/test/test-overlay.html
+++ b/test/test-overlay.html
@@ -15,13 +15,23 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <dom-module id="test-overlay">
 
   <style>
-
     :host {
       background: white;
       color: black;
       border: 1px solid black;
     }
 
+    :host([animated]) {
+      -webkit-transition: -webkit-transform 0.3s;
+      transition: transform 0.3s;
+      -webkit-transform: translateY(300px);
+      transform: translateY(300px);
+    }
+
+    :host(.opened[animated]) {
+      -webkit-transform: translateY(0px);
+      transform: translateY(0px);
+    }
   </style>
 
   <template>
@@ -31,19 +41,62 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 </dom-module>
 
 <script>
+  (function() {
 
-(function() {
+    Polymer({
 
-  Polymer({
+      is: 'test-overlay',
 
-    is: 'test-overlay',
+      properties: {
+        animated: {
+          type: Boolean,
+          reflectToAttribute: true
+        }
+      },
 
-    behaviors: [
-      Polymer.IronOverlayBehavior
-    ]
+      behaviors: [
+        Polymer.IronOverlayBehavior
+      ],
 
-  });
+      listeners: {
+        'transitionend': '__onTransitionEnd'
+      },
 
-})();
+      _renderOpened: function() {
+        if (this.animated) {
+          if (this.withBackdrop) {
+            this.backdropElement.open();
+          }
+          this.classList.add('opened');
+          this.fire('simple-overlay-open-animation-start');
+        } else {
+          Polymer.IronOverlayBehaviorImpl._renderOpened.apply(this, arguments);
+        }
+      },
 
+      _renderClosed: function() {
+        if (this.animated) {
+          if (this.withBackdrop) {
+            this.backdropElement.close();
+          }
+          this.classList.remove('opened');
+          this.fire('simple-overlay-close-animation-start');
+        } else {
+          Polymer.IronOverlayBehaviorImpl._renderClosed.apply(this, arguments);
+        }
+      },
+
+      __onTransitionEnd: function(e) {
+        if (e && e.target === this) {
+          if (this.opened) {
+            this._finishRenderOpened();
+          } else {
+            this._finishRenderClosed();
+          }
+        }
+      },
+
+    });
+
+  })();
 </script>


### PR DESCRIPTION
Fixes animation issue for `paper-toast` and `iron-dropdown` happening with the latest `iron-overlay-behavior` (on master). `paper-toast` would not translate when opened, and `iron-dropdown` would blink on safari.

Added `use strict`; did the `display` flipping only on opened (saves a `refit`!). Moved the `_prepareRenderOpened` method (which does the `refit` & `display` flipping) into the `requestAnimationFrame`, for optimal performance.