### PR TITLE
defer _renderOpen/_renderClose after attached

### DIFF
--- a/iron-overlay-behavior.html
+++ b/iron-overlay-behavior.html
@@ -322,16 +322,23 @@ context. You should place this element as a child of `<body>` whenever possible.
 
       this._manager.addOrRemoveOverlay(this);
 
-      this.__isAnimating = true;
-
-      // requestAnimationFrame for non-blocking rendering
       if (this.__openChangedAsync) {
         window.cancelAnimationFrame(this.__openChangedAsync);
       }
+
+      // Defer any animation-related code on attached
+      // (_openedChanged gets called again on attached).
+      if (!this.isAttached) {
+        return;
+      }
+
+      this.__isAnimating = true;
+
       if (this.opened) {
         if (this.withBackdrop) {
           this.backdropElement.prepare();
         }
+        // requestAnimationFrame for non-blocking rendering
         this.__openChangedAsync = window.requestAnimationFrame(function() {
           this.__openChangedAsync = null;
           this._prepareRenderOpened();

--- a/test/iron-overlay-behavior.html
+++ b/test/iron-overlay-behavior.html
@@ -155,6 +155,21 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           assert.equal(getComputedStyle(overlay).display, 'none', 'overlay starts hidden');
         });
 
+        test('_renderOpened called only after is attached', function(done) {
+          var overlay = document.createElement('test-overlay');
+          // The overlay is ready at this point, but not yet attached.
+          var spy = sinon.spy(overlay, '_renderOpened');
+          // This triggers _openedChanged.
+          overlay.opened = true;
+          // Even if not attached yet, overlay should be the current overlay!
+          assert.equal(overlay, overlay._manager.currentOverlay(), 'currentOverlay ok');
+          // Wait long enough for requestAnimationFrame callback.
+          overlay.async(function() {
+            assert.isFalse(spy.called, '_renderOpened not called');
+            done();
+          }, 100);
+        });
+
         test('overlay open/close events', function(done) {
           var nevents = 0;
 


### PR DESCRIPTION
Fixes #158.
`iron-overlay-behavior` was calling `requestAnimationFrame` before it was actually attached to the dom. This would put it in a weird status that might cause wrong bounds calculation (e.g. for `iron-dropdown`). Since elements extending this behavior might memoize position information to save relayouts, those memoized values would end up being wrong (because calculated before the element is actually attached). These wrong calculations end up being different according to the browser, so long story short: wait to be attached, then render opened!