### PR TITLE
withBackdrop prevents click outside

### DIFF
--- a/iron-overlay-manager.html
+++ b/iron-overlay-manager.html
@@ -339,6 +339,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       var overlay = /** @type {?} */ (this.currentOverlay());
       // Check if clicked outside of top overlay.
       if (overlay && this._overlayInPath(Polymer.dom(event).path) !== overlay) {
+        if (overlay.withBackdrop) {
+          // There's no need to stop the propagation as the backdrop element
+          // already got this mousedown/touchstart event. Calling preventDefault
+          // on this event ensures that click/tap won't be triggered at all.
+          event.preventDefault();
+        }
         overlay._onCaptureClick(event);
       }
     },

--- a/test/iron-overlay-behavior.html
+++ b/test/iron-overlay-behavior.html
@@ -766,6 +766,27 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             done();
           });
         });
+
+        test('withBackdrop = true prevents click outside event', function(done) {
+          runAfterOpen(overlay, function() {
+            overlay.addEventListener('iron-overlay-canceled', function(event) {
+              assert.isTrue(event.detail.defaultPrevented, 'click event prevented');
+              done();
+            });
+            MockInteractions.tap(document.body);
+          });
+        });
+
+        test('withBackdrop = false does not prevent click outside event', function(done) {
+          overlay.withBackdrop = false;
+          runAfterOpen(overlay, function() {
+            overlay.addEventListener('iron-overlay-canceled', function(event) {
+              assert.isFalse(event.detail.defaultPrevented, 'click event not prevented');
+              done();
+            });
+            MockInteractions.tap(document.body);
+          });
+        });
       });
 
       suite('multiple overlays', function() {


### PR DESCRIPTION
Fixes #160 by calling `event.preventDefault()` for overlays with backdrop. This ensures that click/tap events don't go beyond the `backdropElement`.