### PR TITLE
Move backdrop updates to manager

### DIFF
--- a/iron-overlay-backdrop.html
+++ b/iron-overlay-backdrop.html
@@ -30,7 +30,6 @@ Custom property | Description | Default
 <dom-module id="iron-overlay-backdrop">
 
   <style>
-
     :host {
       position: fixed;
       top: 0;
@@ -41,17 +40,14 @@ Custom property | Description | Default
       opacity: 0;
       transition: opacity 0.2s;
       pointer-events: none;
-
       @apply(--iron-overlay-backdrop);
     }
 
-    :host([opened]) {
+    :host(.opened) {
       opacity: var(--iron-overlay-backdrop-opacity, 0.6);
       pointer-events: auto;
-
       @apply(--iron-overlay-backdrop-opened);
     }
-
   </style>
 
   <template>
@@ -61,9 +57,6 @@ Custom property | Description | Default
 </dom-module>
 
 <script>
-
-(function() {
-
   Polymer({
 
     is: 'iron-overlay-backdrop',
@@ -74,10 +67,10 @@ Custom property | Description | Default
        * Returns true if the backdrop is opened.
        */
       opened: {
-        readOnly: true,
-        reflectToAttribute: true,
         type: Boolean,
-        value: false
+        value: false,
+        readOnly: true,
+        observer: '_openedChanged'
       },
 
       _manager: {
@@ -87,8 +80,26 @@ Custom property | Description | Default
 
     },
 
+    get _noAnimation() {
+      var cs = getComputedStyle(this);
+      return (cs.transitionDuration === '0s' || cs.opacity == 0);
+    },
+
     listeners: {
-      'transitionend' : '_onTransitionend'
+      'transitionend': '_onTransitionend'
+    },
+
+    created: function() {
+      // Used to determine if the backdrop should be removed from the parent after is closed.
+      this.__removeOnClose = false;
+      // Used to cancel previous requestAnimationFrame calls when opened changes.
+      this.__openedRaf = null;
+    },
+
+    attached: function() {
+      if (this.opened) {
+        this._openedChanged();
+      }
     },
 
     /**
@@ -96,6 +107,7 @@ Custom property | Description | Default
      */
     prepare: function() {
       if (!this.parentNode) {
+        this.__removeOnClose = true;
         Polymer.dom(document.body).appendChild(this);
       }
     },
@@ -105,8 +117,8 @@ Custom property | Description | Default
      */
     open: function() {
       // only need to make the backdrop visible if this is called by the first overlay with a backdrop
-      if (this._manager.getBackdrops().length < 2) {
-        this._setOpened(true);
+      if (this._manager.getBackdrops().length > 0) {
+        this.setOpened(true);
       }
     },
 
@@ -116,14 +128,20 @@ Custom property | Description | Default
     close: function() {
       // close only if no element with backdrop is left
       if (this._manager.getBackdrops().length === 0) {
-        // Read style before setting opened.
-        var cs = getComputedStyle(this);
-        var noAnimation = (cs.transitionDuration === '0s' || cs.opacity == 0);
-        this._setOpened(false);
-        // In case of no animations, complete
-        if (noAnimation) {
-          this.complete();
-        }
+        this.setOpened(false);
+      }
+    },
+
+
+    /**
+     * Updates opened.
+     */
+    setOpened: function(opened) {
+      this._setOpened(opened);
+      if (opened) {
+        this.prepare();
+      } else if (this.__removeOnClose && this._noAnimation) {
+        this.complete();
       }
     },
 
@@ -131,20 +149,36 @@ Custom property | Description | Default
      * Removes the backdrop from document body if needed.
      */
     complete: function() {
-      // only remove the backdrop if there are no more overlays with backdrops
-      if (this._manager.getBackdrops().length === 0 && this.parentNode) {
+      if (!this.opened && this.__removeOnClose) {
         Polymer.dom(this.parentNode).removeChild(this);
+        this.__removeOnClose = false;
       }
     },
 
-    _onTransitionend: function (event) {
+    _onTransitionend: function(event) {
       if (event && event.target === this) {
         this.complete();
       }
+    },
+
+    _openedChanged: function() {
+      if (!this.isAttached) {
+        return;
+      }
+      if (this.__openedRaf) {
+        window.cancelAnimationFrame(this.__openedRaf);
+        this.__openedRaf = null;
+      }
+      // Force relayout to ensure proper transitions.
+      this.scrollTop = this.scrollTop;
+      this.__openedRaf = window.requestAnimationFrame(function() {
+        this.__openedRaf = null;
+        if (this.opened) {
+          this.classList.add('opened');
+        } else {
+          this.classList.remove('opened');
+        }
+      }.bind(this));
     }
-
   });
-
-})();
-
 </script>

--- a/iron-overlay-backdrop.html
+++ b/iron-overlay-backdrop.html
@@ -57,6 +57,10 @@ Custom property | Description | Default
 </dom-module>
 
 <script>
+// IIFE to help scripts concatenation.
+(function() {
+'use strict';
+
   Polymer({
 
     is: 'iron-overlay-backdrop',
@@ -67,9 +71,10 @@ Custom property | Description | Default
        * Returns true if the backdrop is opened.
        */
       opened: {
+        readOnly: true,
+        reflectToAttribute: true,
         type: Boolean,
         value: false,
-        readOnly: true,
         observer: '_openedChanged'
       },
 
@@ -90,16 +95,12 @@ Custom property | Description | Default
     },
 
     created: function() {
-      // Used to determine if the backdrop should be removed from the parent after is closed.
-      this.__removeOnClose = false;
       // Used to cancel previous requestAnimationFrame calls when opened changes.
       this.__openedRaf = null;
     },
 
     attached: function() {
-      if (this.opened) {
-        this._openedChanged();
-      }
+      this.opened && this._openedChanged(this.opened);
     },
 
     /**
@@ -107,7 +108,6 @@ Custom property | Description | Default
      */
     prepare: function() {
       if (!this.parentNode) {
-        this.__removeOnClose = true;
         Polymer.dom(document.body).appendChild(this);
       }
     },
@@ -140,7 +140,7 @@ Custom property | Description | Default
       this._setOpened(opened);
       if (opened) {
         this.prepare();
-      } else if (this.__removeOnClose && this._noAnimation) {
+      } else if (this._noAnimation) {
         this.complete();
       }
     },
@@ -149,9 +149,8 @@ Custom property | Description | Default
      * Removes the backdrop from document body if needed.
      */
     complete: function() {
-      if (!this.opened && this.__removeOnClose) {
+      if (!this.opened && this.parentNode) {
         Polymer.dom(this.parentNode).removeChild(this);
-        this.__removeOnClose = false;
       }
     },
 
@@ -173,12 +172,11 @@ Custom property | Description | Default
       this.scrollTop = this.scrollTop;
       this.__openedRaf = window.requestAnimationFrame(function() {
         this.__openedRaf = null;
-        if (this.opened) {
-          this.classList.add('opened');
-        } else {
-          this.classList.remove('opened');
-        }
+        this.toggleClass('opened', this.opened);
       }.bind(this));
     }
   });
+
+})();
+
 </script>

--- a/iron-overlay-backdrop.html
+++ b/iron-overlay-backdrop.html
@@ -9,7 +9,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 -->
 
 <link rel="import" href="../polymer/polymer.html">
-<link rel="import" href="iron-overlay-manager.html">
 
 <!--
 `iron-overlay-backdrop` is a backdrop used by `Polymer.IronOverlayBehavior`. It should be a
@@ -57,7 +56,6 @@ Custom property | Description | Default
 </dom-module>
 
 <script>
-// IIFE to help scripts concatenation.
 (function() {
 'use strict';
 
@@ -71,23 +69,12 @@ Custom property | Description | Default
        * Returns true if the backdrop is opened.
        */
       opened: {
-        readOnly: true,
         reflectToAttribute: true,
         type: Boolean,
         value: false,
         observer: '_openedChanged'
-      },
-
-      _manager: {
-        type: Object,
-        value: Polymer.IronOverlayManager
       }
 
-    },
-
-    get _noAnimation() {
-      var cs = getComputedStyle(this);
-      return (cs.transitionDuration === '0s' || cs.opacity == 0);
     },
 
     listeners: {
@@ -104,52 +91,33 @@ Custom property | Description | Default
     },
 
     /**
-     * Appends the backdrop to document body and sets its `z-index` to be below the latest overlay.
+     * Appends the backdrop to document body if needed.
      */
     prepare: function() {
-      if (!this.parentNode) {
+      if (this.opened && !this.parentNode) {
         Polymer.dom(document.body).appendChild(this);
       }
     },
 
     /**
-     * Shows the backdrop if needed.
+     * Shows the backdrop.
      */
     open: function() {
-      // only need to make the backdrop visible if this is called by the first overlay with a backdrop
-      if (this._manager.getBackdrops().length > 0) {
-        this.setOpened(true);
-      }
+      this.opened = true;
     },
 
     /**
-     * Hides the backdrop if needed.
+     * Hides the backdrop.
      */
     close: function() {
-      // close only if no element with backdrop is left
-      if (this._manager.getBackdrops().length === 0) {
-        this.setOpened(false);
-      }
-    },
-
-
-    /**
-     * Updates opened.
-     */
-    setOpened: function(opened) {
-      this._setOpened(opened);
-      if (opened) {
-        this.prepare();
-      } else if (this._noAnimation) {
-        this.complete();
-      }
+      this.opened = false;
     },
 
     /**
      * Removes the backdrop from document body if needed.
      */
     complete: function() {
-      if (!this.opened && this.parentNode) {
+      if (!this.opened && this.parentNode === document.body) {
         Polymer.dom(this.parentNode).removeChild(this);
       }
     },
@@ -161,9 +129,23 @@ Custom property | Description | Default
     },
 
     _openedChanged: function() {
+      if (this.opened) {
+        // Auto-attach.
+        this.prepare();
+      } else {
+        // Animation might be disabled via the mixin or opacity custom property.
+        // If it is disabled in other ways, it's up to the user to call complete.
+        var cs = window.getComputedStyle(this);
+        if (cs.transitionDuration === '0s' || cs.opacity == 0) {
+          this.complete();
+        }
+      }
+
       if (!this.isAttached) {
         return;
       }
+
+      // Always cancel previous requestAnimationFrame.
       if (this.__openedRaf) {
         window.cancelAnimationFrame(this.__openedRaf);
         this.__openedRaf = null;

--- a/iron-overlay-behavior.html
+++ b/iron-overlay-behavior.html
@@ -11,7 +11,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../iron-fit-behavior/iron-fit-behavior.html">
 <link rel="import" href="../iron-resizable-behavior/iron-resizable-behavior.html">
-<link rel="import" href="iron-overlay-backdrop.html">
 <link rel="import" href="iron-overlay-manager.html">
 
 <script>

--- a/iron-overlay-behavior.html
+++ b/iron-overlay-behavior.html
@@ -255,10 +255,6 @@ context. You should place this element as a child of `<body>` whenever possible.
       Polymer.dom(this).unobserveNodes(this._observer);
       this._observer = null;
       this.opened = false;
-      if (this.withBackdrop) {
-        // Allow user interactions right away.
-        this.backdropElement.close();
-      }
     },
 
     /**
@@ -335,9 +331,6 @@ context. You should place this element as a child of `<body>` whenever possible.
       this.__isAnimating = true;
 
       if (this.opened) {
-        if (this.withBackdrop) {
-          this.backdropElement.prepare();
-        }
         // requestAnimationFrame for non-blocking rendering
         this.__openChangedAsync = window.requestAnimationFrame(function() {
           this.__openChangedAsync = null;
@@ -365,15 +358,6 @@ context. You should place this element as a child of `<body>` whenever possible.
       }
       if (this.opened) {
         this._manager.trackBackdrop();
-        if (this.withBackdrop) {
-          this.backdropElement.prepare();
-          // Give time to be added to document.
-          this.async(function(){
-            this.backdropElement.open();
-          }, 1);
-        } else {
-          this.backdropElement.close();
-        }
       }
     },
 
@@ -401,9 +385,6 @@ context. You should place this element as a child of `<body>` whenever possible.
      * @protected
      */
     _renderOpened: function() {
-      if (this.withBackdrop) {
-        this.backdropElement.open();
-      }
       this._finishRenderOpened();
     },
 
@@ -412,9 +393,6 @@ context. You should place this element as a child of `<body>` whenever possible.
      * @protected
      */
     _renderClosed: function() {
-      if (this.withBackdrop) {
-        this.backdropElement.close();
-      }
       this._finishRenderClosed();
     },
 

--- a/iron-overlay-behavior.html
+++ b/iron-overlay-behavior.html
@@ -15,7 +15,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="iron-overlay-manager.html">
 
 <script>
-// IIFE to help scripts concatenation.
 (function() {
 'use strict';
 

--- a/iron-overlay-manager.html
+++ b/iron-overlay-manager.html
@@ -225,6 +225,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      */
     trackBackdrop: function() {
       this.backdropElement.style.zIndex = this.backdropZ();
+      this.backdropElement.setOpened(!!this._overlayWithBackdrop());
     },
 
     /**

--- a/iron-overlay-manager.html
+++ b/iron-overlay-manager.html
@@ -230,7 +230,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         return;
       }
       this.backdropElement.style.zIndex = this._getZ(overlay) - 1;
-      this.backdropElement.setOpened(!!overlay);
+      this.backdropElement.opened = !!overlay;
     },
 
     /**

--- a/iron-overlay-manager.html
+++ b/iron-overlay-manager.html
@@ -10,6 +10,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../iron-a11y-keys-behavior/iron-a11y-keys-behavior.html">
+<link rel="import" href="iron-overlay-backdrop.html">
 
 <script>
 

--- a/iron-overlay-manager.html
+++ b/iron-overlay-manager.html
@@ -224,8 +224,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      * Updates the backdrop z-index.
      */
     trackBackdrop: function() {
-      this.backdropElement.style.zIndex = this.backdropZ();
-      this.backdropElement.setOpened(!!this._overlayWithBackdrop());
+      var overlay = this._overlayWithBackdrop();
+      // Avoid creating the backdrop if there is no overlay with backdrop.
+      if (!overlay && !this._backdropElement) {
+        return;
+      }
+      this.backdropElement.style.zIndex = this._getZ(overlay) - 1;
+      this.backdropElement.setOpened(!!overlay);
     },
 
     /**

--- a/test/iron-overlay-behavior.html
+++ b/test/iron-overlay-behavior.html
@@ -700,10 +700,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
 
         test('backdrop is opened when overlay is opened', function(done) {
-          assert.isDefined(overlay.backdropElement, 'backdrop is defined');
+          assert.isOk(overlay.backdropElement, 'backdrop is defined');
           runAfterOpen(overlay, function() {
             assert.isTrue(overlay.backdropElement.opened, 'backdrop is opened');
-            assert.isDefined(overlay.backdropElement.parentNode, 'backdrop is inserted in the DOM');
+            assert.isOk(overlay.backdropElement.parentNode, 'backdrop is inserted in the DOM');
             done();
           });
         });


### PR DESCRIPTION
`iron-overlay-backdrop` now allows to set `opened` synchronously, and animation to `opened` state is handled with a css class instead of attribute, using `requestAnimationFrame` for better performance.
Removed the dependency to `iron-overlay-manager` as it was needed to limit when the backdrop can be opened or not. This part is controlled by the manager itself now.

`iron-overlay-behavior` delegates the updates of `backdropElement`'s `opened` state to `iron-overlay-manager`.

