### PR TITLE
fix: make overlay display over backdrop, by appending overlay to body

### DIFF
--- a/iron-overlay-behavior.html
+++ b/iron-overlay-behavior.html
@@ -88,6 +88,22 @@ context. You should place this element as a child of `<body>` whenever possible.
       },
 
       /**
+       * Set to true for this overlay to remain a child of its original
+       * parent element.
+       *
+       * By default, this overlay element appends both its overlay
+       * and its backdrop as an immediate child of the `body` element.
+       *
+       * If you want to keep the overlay as a child of its original
+       * parent element, set `keepWithParent` to "true".
+       */
+      keepWithParent: {
+        type: Boolean,
+        default: false,
+        notify: true
+      },
+
+      /**
        * Set to true to disable auto-focusing the overlay or child nodes with
        * the `autofocus` attribute` when the overlay is opened.
        */
@@ -246,6 +262,10 @@ context. You should place this element as a child of `<body>` whenever possible.
     },
 
     attached: function() {
+      // Append overlay to body element
+      if (this.keepWithParent !== true) {
+        document.querySelector('body').appendChild(this);
+      }
       // Call _openedChanged here so that position can be computed correctly.
       if (this.opened) {
         this._openedChanged();

--- a/iron-overlay-behavior.html
+++ b/iron-overlay-behavior.html
@@ -264,7 +264,7 @@ context. You should place this element as a child of `<body>` whenever possible.
     attached: function() {
       // Append overlay to body element
       if (this.keepWithParent !== true) {
-        document.querySelector('body').appendChild(this);
+        Polymer.dom(document.body).appendChild(this);
       }
       // Call _openedChanged here so that position can be computed correctly.
       if (this.opened) {


### PR DESCRIPTION
Fixes https://github.com/PolymerElements/paper-dialog/issues/7
Fixes https://github.com/PolymerElements/polymer-starter-kit/issues/154
Fixes (maybe) https://github.com/PolymerElements/paper-dialog/issues/79
Fixes (maybe) https://github.com/PolymerElements/paper-dialog/issues/44
Fixes (maybe) https://github.com/PolymerElements/paper-drawer-panel/issues/122
Related to https://github.com/PolymerElements/iron-overlay-behavior/pull/72
Related to https://github.com/PolymerElements/iron-overlay-behavior/pull/86
Related to https://github.com/PolymerElements/iron-overlay-behavior/compare/backdrop-refit
Fixes (maybe) https://github.com/PolymerElements/paper-dialog-behavior/issues/78
Fixes https://github.com/PolymerLabs/app-layout/issues/155