### PR TITLE
force focus wrapping

### DIFF
--- a/iron-overlay-behavior.html
+++ b/iron-overlay-behavior.html
@@ -516,6 +516,16 @@ context. You should place this element as a child of `<body>` whenever possible.
       var nodeToCheck = shift ? this.__firstFocusableNode : this.__lastFocusableNode;
       var nodeToSet = shift ? this.__lastFocusableNode : this.__firstFocusableNode;
       if (this.withBackdrop && this._focusedChild === nodeToCheck) {
+        // When the overlay contains the last focusable element of the document
+        // and it's already focused, pressing TAB would move the focus outside
+        // the document (e.g. to the browser search bar). Similarly, when the
+        // overlay contains the first focusable element of the document and it's
+        // already focused, pressing Shift+TAB would move the focus outside the
+        // document (e.g. to the browser search bar).
+        // In both cases, we would not receive a focus event, but only a blur.
+        // In order to achieve focus wrapping, we prevent this TAB event and
+        // force the focus. This will also prevent the focus to temporarily move
+        // outside the overlay, which might cause scrolling.
         event.preventDefault();
         this._focusedChild = nodeToSet;
         this._applyFocus();

--- a/iron-overlay-behavior.html
+++ b/iron-overlay-behavior.html
@@ -516,9 +516,9 @@ context. You should place this element as a child of `<body>` whenever possible.
       var nodeToCheck = shift ? this.__firstFocusableNode : this.__lastFocusableNode;
       var nodeToSet = shift ? this.__lastFocusableNode : this.__firstFocusableNode;
       if (this.withBackdrop && this._focusedChild === nodeToCheck) {
-        // We set here the _focusedChild so that _onCaptureFocus will handle the
-        // wrapping of the focus (the next event after tab is focus).
+        event.preventDefault();
         this._focusedChild = nodeToSet;
+        this._applyFocus();
       }
     },
 

--- a/test/iron-overlay-behavior.html
+++ b/test/iron-overlay-behavior.html
@@ -553,15 +553,21 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             Polymer.Base.async(function() {
               // Go to last element.
               MockInteractions.focus(focusableNodes[focusableNodes.length-1]);
-              // Simulate TAB & focus out of overlay.
+              // Spy keydown.
+              var tabSpy = sinon.spy();
+              document.addEventListener('keydown', tabSpy);
+              // Simulate TAB.
               MockInteractions.pressAndReleaseKeyOn(document, 9);
-              MockInteractions.focus(document.body);
-
               assert.equal(focusableNodes[0], document.activeElement, 'focus wrapped to first focusable');
-              // Simulate Shift+TAB & focus out of overlay.
+              assert.isTrue(tabSpy.calledOnce, 'keydown spy called');
+              assert.isTrue(tabSpy.getCall(0).args[0].defaultPrevented, 'keydown default prevented');
+              // Simulate Shift+TAB.
               MockInteractions.pressAndReleaseKeyOn(document, 9, ['shift']);
-              MockInteractions.focus(document.body);
               assert.equal(focusableNodes[focusableNodes.length-1], document.activeElement, 'focus wrapped to last focusable');
+              assert.isTrue(tabSpy.calledTwice, 'keydown spy called again');
+              assert.isTrue(tabSpy.getCall(1).args[0].defaultPrevented, 'keydown default prevented again');
+              // Cleanup.
+              document.removeEventListener('keydown', tabSpy);
               done();
             }, 1);
           });
@@ -574,13 +580,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             Polymer.Base.async(function() {
               // Go to last element.
               MockInteractions.focus(focusableNodes[focusableNodes.length-1]);
-              // Simulate TAB & focus out of overlay.
+              // Simulate TAB.
               MockInteractions.pressAndReleaseKeyOn(document, 9);
-              MockInteractions.focus(document.body);
               assert.equal(focusableNodes[0], document.activeElement, 'focus wrapped to first focusable');
-              // Simulate Shift+TAB & focus out of overlay.
+              // Simulate Shift+TAB.
               MockInteractions.pressAndReleaseKeyOn(document, 9, ['shift']);
-              MockInteractions.focus(document.body);
               assert.equal(focusableNodes[focusableNodes.length-1], document.activeElement, 'focus wrapped to last focusable');
               done();
             }, 1);


### PR DESCRIPTION
Fixes #170 by preventing event default and forcing the focus to wrap instead of relying on focus change.