### PR TITLE
check for deepest active element

### DIFF
--- a/iron-overlay-behavior.html
+++ b/iron-overlay-behavior.html
@@ -510,12 +510,32 @@ context. You should place this element as a child of `<body>` whenever possible.
      * @protected
      */
     _onCaptureTab: function(event) {
+      if (!this.withBackdrop) {
+        return;
+      }
       // TAB wraps from last to first focusable.
       // Shift + TAB wraps from first to last focusable.
       var shift = event.shiftKey;
       var nodeToCheck = shift ? this.__firstFocusableNode : this.__lastFocusableNode;
       var nodeToSet = shift ? this.__lastFocusableNode : this.__firstFocusableNode;
-      if (this.withBackdrop && this._focusedChild === nodeToCheck) {
+      var shouldWrap = false;
+      if (nodeToCheck === nodeToSet) {
+        // If nodeToCheck is the same as nodeToSet, it means we have an overlay
+        // with 0 or 1 focusables; in either case we still need to trap the
+        // focus within the overlay.
+        shouldWrap = true;
+      } else {
+        // In dom=shadow, the manager will receive focus changes on the main
+        // root but not the ones within other shadow roots, so we can't rely on
+        // _focusedChild, but we should check the deepest active element.
+        var focusedNode = this._manager.deepActiveElement;
+        // If the active element is not the nodeToCheck but the overlay itself,
+        // it means the focus is about to go outside the overlay, hence we
+        // should prevent that (e.g. user opens the overlay and hit Shift+TAB).
+        shouldWrap = (focusedNode === nodeToCheck || focusedNode === this);
+      }
+
+      if (shouldWrap) {
         // When the overlay contains the last focusable element of the document
         // and it's already focused, pressing TAB would move the focus outside
         // the document (e.g. to the browser search bar). Similarly, when the

--- a/test/iron-overlay-behavior.html
+++ b/test/iron-overlay-behavior.html
@@ -116,10 +116,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     <test-fixture id="composed">
       <template>
-        <test-menu-button>
-          Composed overlay
-          <button>Button</button>
-        </test-menu-button>
+        <test-menu-button></test-menu-button>
       </template>
     </test-fixture>
 
@@ -509,6 +506,47 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           });
         });
 
+        test('overlay with-backdrop and 1 focusable: prevent TAB and trap the focus', function(done) {
+          overlay.withBackdrop = true;
+          runAfterOpen(overlay, function() {
+            // 1ms timeout needed by IE10 to have proper focus switching.
+            Polymer.Base.async(function() {
+              // Spy keydown.
+              var tabSpy = sinon.spy();
+              document.addEventListener('keydown', tabSpy);
+              // Simulate TAB.
+              MockInteractions.pressAndReleaseKeyOn(document, 9);
+              assert.equal(Polymer.dom(overlay).querySelector('[autofocus]'), document.activeElement, 'focus stays on button');
+              assert.isTrue(tabSpy.calledOnce, 'keydown spy called');
+              assert.isTrue(tabSpy.getCall(0).args[0].defaultPrevented, 'keydown default prevented');
+              // Cleanup.
+              document.removeEventListener('keydown', tabSpy);
+              done();
+            }, 1);
+          });
+        });
+
+        test('empty overlay with-backdrop: prevent TAB and trap the focus', function(done) {
+          overlay = fixture('basic');
+          overlay.withBackdrop = true;
+          runAfterOpen(overlay, function() {
+            // 1ms timeout needed by IE10 to have proper focus switching.
+            Polymer.Base.async(function() {
+              // Spy keydown.
+              var tabSpy = sinon.spy();
+              document.addEventListener('keydown', tabSpy);
+              // Simulate TAB.
+              MockInteractions.pressAndReleaseKeyOn(document, 9);
+              assert.equal(overlay, document.activeElement, 'focus stays on overlay');
+              assert.isTrue(tabSpy.calledOnce, 'keydown spy called');
+              assert.isTrue(tabSpy.getCall(0).args[0].defaultPrevented, 'keydown default prevented');
+              // Cleanup.
+              document.removeEventListener('keydown', tabSpy);
+              done();
+            }, 1);
+          });
+        });
+
       });
 
       suite('focusable nodes', function() {
@@ -550,9 +588,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           overlay.withBackdrop = true;
           var focusableNodes = overlay._focusableNodes;
           runAfterOpen(overlay, function() {
+            // 1ms timeout needed by IE10 to have proper focus switching.
             Polymer.Base.async(function() {
               // Go to last element.
-              MockInteractions.focus(focusableNodes[focusableNodes.length-1]);
+              focusableNodes[focusableNodes.length-1].focus();
               // Spy keydown.
               var tabSpy = sinon.spy();
               document.addEventListener('keydown', tabSpy);
@@ -577,15 +616,37 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           overlayWithTabIndex.withBackdrop = true;
           var focusableNodes = overlayWithTabIndex._focusableNodes;
           runAfterOpen(overlayWithTabIndex, function() {
+            // 1ms timeout needed by IE10 to have proper focus switching.
             Polymer.Base.async(function() {
               // Go to last element.
-              MockInteractions.focus(focusableNodes[focusableNodes.length-1]);
+              focusableNodes[focusableNodes.length-1].focus();
               // Simulate TAB.
               MockInteractions.pressAndReleaseKeyOn(document, 9);
               assert.equal(focusableNodes[0], document.activeElement, 'focus wrapped to first focusable');
               // Simulate Shift+TAB.
               MockInteractions.pressAndReleaseKeyOn(document, 9, ['shift']);
               assert.equal(focusableNodes[focusableNodes.length-1], document.activeElement, 'focus wrapped to last focusable');
+              done();
+            }, 1);
+          });
+        });
+
+        test('with-backdrop: Shift+TAB after open wrap focus', function(done) {
+          overlay.withBackdrop = true;
+          var focusableNodes = overlay._focusableNodes;
+          runAfterOpen(overlay, function() {
+            // 1ms timeout needed by IE10 to have proper focus switching.
+            Polymer.Base.async(function() {
+              // Spy keydown.
+              var tabSpy = sinon.spy();
+              document.addEventListener('keydown', tabSpy);
+              // Simulate Shift+TAB.
+              MockInteractions.pressAndReleaseKeyOn(document, 9, ['shift']);
+              assert.equal(focusableNodes[focusableNodes.length-1], document.activeElement, 'focus wrapped to last focusable');
+              assert.isTrue(tabSpy.calledOnce, 'keydown spy called');
+              assert.isTrue(tabSpy.getCall(0).args[0].defaultPrevented, 'keydown default prevented');
+              // Cleanup.
+              document.removeEventListener('keydown', tabSpy);
               done();
             }, 1);
           });
@@ -1013,18 +1074,51 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       });
 
       suite('overlay in composed tree', function() {
-        test('click on overlay content does not close it', function(done) {
-          var composed = fixture('composed');
-          // Opens overlay.
-          MockInteractions.tap(composed.$.trigger);
-          composed.$.dropdown.addEventListener('iron-overlay-opened', function() {
-            // Tap on button inside overlay.
-            MockInteractions.tap(Polymer.dom(composed).querySelector('button'));
-            Polymer.Base.async(function(){
-              assert.isTrue(composed.$.dropdown.opened, 'overlay still opened');
-              done();
-            }, 1);
+        var composed, overlay, trigger;
+        setup(function(done) {
+          composed = fixture('composed');
+          overlay = composed.$.overlay;
+          trigger = composed.$.trigger;
+          overlay.withBackdrop = true;
+          overlay.addEventListener('iron-overlay-opened', function() {
+            done();
           });
+          // Opens the overlay.
+          MockInteractions.tap(trigger);
+        });
+
+        test('click on overlay content does not close it', function(done) {
+          // Tap on button inside overlay.
+          MockInteractions.tap(Polymer.dom(overlay).querySelector('button'));
+          Polymer.Base.async(function(){
+            assert.isTrue(overlay.opened, 'overlay still opened');
+            done();
+          }, 1);
+        });
+
+        test('with-backdrop wraps the focus within the overlay', function(done) {
+          // 1ms timeout needed by IE10 to have proper focus switching.
+          Polymer.Base.async(function(){
+            var buttons = Polymer.dom(overlay).querySelectorAll('button');
+            // Go to last element.
+            buttons[buttons.length-1].focus();
+            // Spy keydown.
+            var tabSpy = sinon.spy();
+            document.addEventListener('keydown', tabSpy);
+            // Simulate TAB.
+            MockInteractions.pressAndReleaseKeyOn(document, 9);
+            assert.equal(buttons[0], Polymer.IronOverlayManager.deepActiveElement, 'focus wrapped to first focusable');
+            assert.isTrue(tabSpy.calledOnce, 'keydown spy called');
+            assert.isTrue(tabSpy.getCall(0).args[0].defaultPrevented, 'keydown default prevented');
+            // Simulate Shift+TAB.
+            MockInteractions.pressAndReleaseKeyOn(document, 9, ['shift']);
+            assert.equal(buttons[buttons.length-1], Polymer.IronOverlayManager.deepActiveElement, 'focus wrapped to last focusable');
+            assert.isTrue(tabSpy.calledTwice, 'keydown spy called again');
+            assert.isTrue(tabSpy.getCall(1).args[0].defaultPrevented, 'keydown default prevented again');
+            // Cleanup.
+            document.removeEventListener('keydown', tabSpy);
+            done();
+          }, 1);
         });
 
       });

--- a/test/test-menu-button.html
+++ b/test/test-menu-button.html
@@ -15,8 +15,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <template>
     <button id="trigger" on-click="toggle">Open</button>
-    <test-overlay id="dropdown">
-      <content></content>
+    <test-overlay id="overlay">
+      Composed overlay
+      <button>button 1</button>
+      <button>button 2</button>
     </test-overlay>
   </template>
 
@@ -28,7 +30,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   Polymer({
     is: 'test-menu-button',
     toggle: function() {
-      this.$.dropdown.toggle();
+      this.$.overlay.toggle();
     }
   });
 })();


### PR DESCRIPTION
Fixes #172 by checking `deepActiveElement` instead of `_focusedChild`. 
In `dom=shadow`, `IronOverlayManager` won't see the focus changes in other shadow roots, just the ones happening in the `document` root.