### PR TITLE
_focusableNodes can be overridden.

### DIFF
--- a/iron-overlay-behavior.html
+++ b/iron-overlay-behavior.html
@@ -406,6 +406,12 @@ context. You should place this element as a child of `<body>` whenever possible.
 
       this.notifyResize();
       this.__isAnimating = false;
+
+      // Store it so we don't query too much.
+      var focusableNodes = this._focusableNodes;
+      this.__firstFocusableNode = focusableNodes[0];
+      this.__lastFocusableNode = focusableNodes[focusableNodes.length - 1];
+
       this.fire('iron-overlay-opened');
     },
 
@@ -578,10 +584,6 @@ context. You should place this element as a child of `<body>` whenever possible.
       if (this.opened && !this.__isAnimating) {
         this.notifyResize();
       }
-      // Store it so we don't query too much.
-      var focusableNodes = this._focusableNodes;
-      this.__firstFocusableNode = focusableNodes[0];
-      this.__lastFocusableNode = focusableNodes[focusableNodes.length - 1];
     }
   };
 

--- a/test/iron-overlay-behavior.html
+++ b/test/iron-overlay-behavior.html
@@ -89,6 +89,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           </div>
           <div tabindex="2" class="focusable2">2</div>
         </test-overlay>
+        <test-overlay2>
+          Overlay with optimized focusableNodes getter
+          <button class="focusable1">1</button>
+        </test-overlay2>
       </template>
     </test-fixture>
 
@@ -550,12 +554,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       });
 
       suite('focusable nodes', function() {
-        var overlay, overlayWithTabIndex;
+        var overlay, overlayWithTabIndex, overlayFocusableNodes;
 
         setup(function() {
           var f = fixture('focusables');
           overlay = f[0];
           overlayWithTabIndex = f[1];
+          overlayFocusableNodes = f[2];
         });
 
         test('_focusableNodes returns nodes that are focusable', function() {
@@ -582,6 +587,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           assert.equal(focusableNodes[3], Polymer.dom(overlayWithTabIndex).querySelector('.focusable4'));
           assert.equal(focusableNodes[4], Polymer.dom(overlayWithTabIndex).querySelector('.focusable5'));
           assert.equal(focusableNodes[5], Polymer.dom(overlayWithTabIndex).querySelector('.focusable6'));
+        });
+
+        test('_focusableNodes can be overridden', function() {
+          // It has 1 focusable in the light dom, and 2 in the shadow dom.
+          var focusableNodes = overlayFocusableNodes._focusableNodes;
+          assert.equal(focusableNodes.length, 2, 'length ok');
+          assert.equal(focusableNodes[0], overlayFocusableNodes.$.first, 'first ok');
+          assert.equal(focusableNodes[1], overlayFocusableNodes.$.last, 'last ok');
         });
 
         test('with-backdrop: TAB & Shift+TAB wrap focus', function(done) {
@@ -643,6 +656,26 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
               // Simulate Shift+TAB.
               MockInteractions.pressAndReleaseKeyOn(document, 9, ['shift']);
               assert.equal(focusableNodes[focusableNodes.length-1], document.activeElement, 'focus wrapped to last focusable');
+              assert.isTrue(tabSpy.calledOnce, 'keydown spy called');
+              assert.isTrue(tabSpy.getCall(0).args[0].defaultPrevented, 'keydown default prevented');
+              // Cleanup.
+              document.removeEventListener('keydown', tabSpy);
+              done();
+            }, 1);
+          });
+        });
+
+        test('with-backdrop: Shift+TAB wrap focus in shadowDOM', function(done) {
+          overlayFocusableNodes.withBackdrop = true;
+          runAfterOpen(overlayFocusableNodes, function() {
+            // 1ms timeout needed by IE10 to have proper focus switching.
+            Polymer.Base.async(function() {
+              // Spy keydown.
+              var tabSpy = sinon.spy();
+              document.addEventListener('keydown', tabSpy);
+              // Simulate Shift+TAB.
+              MockInteractions.pressAndReleaseKeyOn(document, 9, ['shift']);
+              assert.equal(overlayFocusableNodes.$.last, Polymer.IronOverlayManager.deepActiveElement, 'focus wrapped to last focusable in the shadowDOM');
               assert.isTrue(tabSpy.calledOnce, 'keydown spy called');
               assert.isTrue(tabSpy.getCall(0).args[0].defaultPrevented, 'keydown default prevented');
               // Cleanup.

--- a/test/test-overlay2.html
+++ b/test/test-overlay2.html
@@ -25,7 +25,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   </style>
 
   <template>
+    <button id="first">first</button>
     <content></content>
+    <button id="last">last</button>
   </template>
 
 </dom-module>
@@ -40,7 +42,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     behaviors: [
       Polymer.IronOverlayBehavior
-    ]
+    ],
+    
+    get _focusableNodes() {
+      return [this.$.first, this.$.last];
+    }
 
   });
 


### PR DESCRIPTION
Fixes #176 by invoking `_focusableNodes` after the overlay is opened instead of during nodes changes.
What was happening previously is that `_focusedNodes` would be called **before** the getter could be overridden by `_onNodesChange`. 
Now, we update the first & last focusable each time an overlay is opened.
Ideally we should have two properties for first and last focusable nodes and deprecate/remove `_focusableNodes`, but that might be a breaking change, while this can qualify as a patch.