### PR TITLE
backdrop moved in overlay root

### DIFF
--- a/iron-overlay-backdrop.html
+++ b/iron-overlay-backdrop.html
@@ -22,7 +22,7 @@ Custom property | Description | Default
 -------------------------------------------|------------------------|---------
 `--iron-overlay-backdrop-background-color` | Backdrop background color                                     | #000
 `--iron-overlay-backdrop-opacity`          | Backdrop opacity                                              | 0.6
-`--iron-overlay-backdrop`                  | Mixin applied to `iron-overlay-backdrop`.                      | {}
+`--iron-overlay-backdrop`                  | Mixin applied to `iron-overlay-backdrop`.                     | {}
 `--iron-overlay-backdrop-opened`           | Mixin applied to `iron-overlay-backdrop` when it is displayed | {}
 -->
 
@@ -31,19 +31,29 @@ Custom property | Description | Default
   <template>
     <style>
       :host {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        outline: 9999px solid var(--iron-overlay-backdrop-background-color, #000);
+        opacity: 0;
+        transition: opacity 0.2s;
+        pointer-events: none;
+        z-index: -1;
+        @apply(--iron-overlay-backdrop);
+      }
+
+      :host::before {
+        content: '';
         position: fixed;
         top: 0;
         left: 0;
         width: 100%;
         height: 100%;
-        background-color: var(--iron-overlay-backdrop-background-color, #000);
-        opacity: 0;
-        transition: opacity 0.2s;
-        pointer-events: none;
-        @apply(--iron-overlay-backdrop);
       }
 
-      :host(.opened) {
+      :host([opened]) {
         opacity: var(--iron-overlay-backdrop-opacity, 0.6);
         pointer-events: auto;
         @apply(--iron-overlay-backdrop-opened);
@@ -77,10 +87,6 @@ Custom property | Description | Default
 
     },
 
-    listeners: {
-      'transitionend': '_onTransitionend'
-    },
-
     created: function() {
       // Used to cancel previous requestAnimationFrame calls when opened changes.
       this.__openedRaf = null;
@@ -91,11 +97,14 @@ Custom property | Description | Default
     },
 
     /**
-     * Appends the backdrop to document body if needed.
+     * Appends the backdrop to the parent if the backdrop is opened.
+     * @param {!Element} parent
      */
-    prepare: function() {
-      if (this.opened && !this.parentNode) {
-        Polymer.dom(document.body).appendChild(this);
+    prepare: function(parent) {
+      var curParent = Polymer.dom(this).parentNode;
+      if (this.opened && curParent !== parent.root) {
+        Polymer.dom(parent.root).appendChild(this);
+        this.updateStyles();
       }
     },
 
@@ -114,17 +123,12 @@ Custom property | Description | Default
     },
 
     /**
-     * Removes the backdrop from document body if needed.
+     * Removes the backdrop from the parent if backdrop is closed.
      */
     complete: function() {
-      if (!this.opened && this.parentNode === document.body) {
-        Polymer.dom(this.parentNode).removeChild(this);
-      }
-    },
-
-    _onTransitionend: function(event) {
-      if (event && event.target === this) {
-        this.complete();
+      var parent = Polymer.dom(this).parentNode;
+      if (!this.opened && parent) {
+        Polymer.dom(parent).removeChild(this);
       }
     },
 
@@ -133,27 +137,16 @@ Custom property | Description | Default
      * @private
      */
     _openedChanged: function(opened) {
-      if (opened) {
-        // Auto-attach.
-        this.prepare();
-      } else {
-        // Animation might be disabled via the mixin or opacity custom property.
-        // If it is disabled in other ways, it's up to the user to call complete.
-        var cs = window.getComputedStyle(this);
-        if (cs.transitionDuration === '0s' || cs.opacity == 0) {
-          this.complete();
-        }
+      // Always cancel previous requestAnimationFrame.
+      if (this.__openedRaf) {
+        window.cancelAnimationFrame(this.__openedRaf);
+        this.__openedRaf = null;
       }
 
       if (!this.isAttached) {
         return;
       }
 
-      // Always cancel previous requestAnimationFrame.
-      if (this.__openedRaf) {
-        window.cancelAnimationFrame(this.__openedRaf);
-        this.__openedRaf = null;
-      }
       // Force relayout to ensure proper transitions.
       this.scrollTop = this.scrollTop;
       this.__openedRaf = window.requestAnimationFrame(function() {

--- a/iron-overlay-backdrop.html
+++ b/iron-overlay-backdrop.html
@@ -44,6 +44,7 @@ Custom property | Description | Default
         @apply(--iron-overlay-backdrop);
       }
 
+      /* Blocks the interactions */
       :host::before {
         content: '';
         position: fixed;
@@ -51,6 +52,8 @@ Custom property | Description | Default
         left: 0;
         width: 100%;
         height: 100%;
+        /* IE10: this makes the element opaque and actually blocks interactions. */
+        background-color: rgba(0, 0, 0, 0.001);
       }
 
       :host([opened]) {

--- a/iron-overlay-behavior.html
+++ b/iron-overlay-behavior.html
@@ -437,7 +437,7 @@ context. You should place this element as a child of `<body>` whenever possible.
      * @protected
      */
     _finishRenderClosed: function() {
-      // Hide the overlay and remove the backdrop.
+      // Hide the overlay.
       this.style.display = 'none';
       // Reset z-index only at the end of the animation.
       this.style.zIndex = '';

--- a/iron-overlay-manager.html
+++ b/iron-overlay-manager.html
@@ -232,8 +232,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       if (!overlay && !this._backdropElement) {
         return;
       }
-      this.backdropElement.style.zIndex = this._getZ(overlay) - 1;
       this.backdropElement.opened = !!overlay;
+      if (overlay && overlay.opened) {
+        this.backdropElement.prepare(overlay);
+      }
     },
 
     /**
@@ -346,9 +348,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      * @private
      */
     _onCaptureClick: function(event) {
+      if (!this._overlays.length) {
+        return;
+      }
       var overlay = /** @type {?} */ (this.currentOverlay());
-      // Check if clicked outside of top overlay.
-      if (overlay && this._overlayInPath(Polymer.dom(event).path) !== overlay) {
+      var path = Polymer.dom(event).path;
+      // Check if clicked outside of top overlay or on the backdrop element.
+      if (this._overlayInPath(path) !== overlay ||
+          (overlay.withBackdrop && path.indexOf(this.backdropElement) !== -1)) {
         overlay._onCaptureClick(event);
       }
     },

--- a/test/iron-overlay-backdrop.html
+++ b/test/iron-overlay-backdrop.html
@@ -70,7 +70,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
                 // Flush so we are sure backdrop is added in the DOM.
                 Polymer.dom.flush();
                 var backdrop = overlay.backdropElement;
-                var parent = backdrop.parentElement;
+                var parent = Polymer.dom(backdrop).parentNode.host;
                 assert.strictEqual(backdrop.offsetWidth, parent.clientWidth, 'backdrop width matches parent width');
                 assert.strictEqual(backdrop.offsetHeight, parent.clientHeight, 'backdrop height matches parent height');
                 done();

--- a/test/iron-overlay-behavior.html
+++ b/test/iron-overlay-behavior.html
@@ -27,15 +27,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <link rel="import" href="test-buttons.html">
     <link rel="import" href="test-menu-button.html">
 
-    <style is="custom-style">
-      iron-overlay-backdrop {
-        /* For quicker tests */
-        --iron-overlay-backdrop: {
-          transition: none;
-        }
-      }
-    </style>
-
   </head>
 
   <body>
@@ -792,45 +783,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           overlay = fixture('backdrop');
         });
 
-        test('backdrop is opened when overlay is opened', function(done) {
+        test('backdrop is opened when overlay is opened, closed when overlay is closed', function(done) {
           assert.isOk(overlay.backdropElement, 'backdrop is defined');
           runAfterOpen(overlay, function() {
             assert.isTrue(overlay.backdropElement.opened, 'backdrop is opened');
-            assert.isOk(overlay.backdropElement.parentNode, 'backdrop is inserted in the DOM');
-            done();
-          });
-        });
-
-        test('backdrop appears behind the overlay', function(done) {
-          runAfterOpen(overlay, function() {
-            styleZ = parseInt(window.getComputedStyle(overlay).zIndex, 10);
-            backdropStyleZ = parseInt(window.getComputedStyle(overlay.backdropElement).zIndex, 10);
-            assert.isTrue(styleZ > backdropStyleZ, 'overlay has higher z-index than backdrop');
-            done();
-          });
-        });
-
-        test('backdrop is removed when overlay is closed', function(done) {
-          runAfterOpen(overlay, function() {
+            assert.equal(Polymer.dom(overlay.backdropElement).parentNode, overlay.root, 'backdrop is inserted in overlay root');
+            assert.isTrue(Polymer.dom(overlay).deepContains(document.elementFromPoint(1, 1)), 'backdrop blocks interactions');
             runAfterClose(overlay, function() {
               assert.isFalse(overlay.backdropElement.opened, 'backdrop is closed');
-              assert.isNotOk(overlay.backdropElement.parentNode, 'backdrop is removed from the DOM');
-              assert.lengthOf(document.querySelectorAll('iron-overlay-backdrop'), 0, 'no backdrop elements on body');
+              assert.isFalse(Polymer.dom(overlay).deepContains(document.elementFromPoint(1, 1)), 'backdrop does NOT block interactions');
               done();
             });
-          });
-        });
-
-        test('backdrop is removed when the element is removed from DOM', function(done) {
-          runAfterOpen(overlay, function() {
-            Polymer.dom(overlay).parentNode.removeChild(overlay);
-            // Ensure detached is executed.
-            Polymer.dom.flush();
-            assert.isFalse(overlay.backdropElement.opened, 'backdrop is closed');
-            assert.isNotOk(overlay.backdropElement.parentNode, 'backdrop is removed from the DOM');
-            assert.lengthOf(document.querySelectorAll('iron-overlay-backdrop'), 0, 'no backdrop elements on body');
-            assert.isNotOk(overlay._manager.currentOverlay(), 'currentOverlay ok');
-            done();
           });
         });
 
@@ -847,16 +810,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           runAfterOpen(overlay, function() {
             overlay.withBackdrop = false;
             assert.isFalse(overlay.backdropElement.opened, 'backdrop is closed');
-            assert.isNotObject(overlay.backdropElement.parentNode, 'backdrop is removed from document');
-            done();
-          });
-        });
-
-        test('backdrop is removed when toggling overlay opened', function(done) {
-          overlay.open();
-          runAfterClose(overlay, function() {
-            assert.isFalse(overlay.backdropElement.opened, 'backdrop is closed');
-            assert.isNotOk(overlay.backdropElement.parentNode, 'backdrop is removed from document');
+            assert.isNotObject(overlay.backdropElement.parentNode, 'backdrop is removed from overlay');
             done();
           });
         });
@@ -1039,37 +993,38 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
 
         test('only one iron-overlay-backdrop in the DOM', function(done) {
-          // Open them all.
-          overlay1.opened = true;
-          overlay2.opened = true;
-          runAfterOpen(overlay3, function() {
-            assert.lengthOf(document.querySelectorAll('iron-overlay-backdrop'), 1, 'only one backdrop element in the DOM');
+          // Open them all (1, 2, then 3).
+          overlay3.opened = overlay2.opened = overlay1.opened = true;
+          overlay3.addEventListener('iron-overlay-opened', function() {
+            assert.lengthOf(Polymer.dom(overlay1.root).querySelectorAll('iron-overlay-backdrop'), 1, 'backdrop in overlay1');
+            assert.lengthOf(Polymer.dom(overlay2.root).querySelectorAll('iron-overlay-backdrop'), 0, 'no backdrop in overlay2');
+            assert.lengthOf(Polymer.dom(overlay3.root).querySelectorAll('iron-overlay-backdrop'), 0, 'no backdrop in overlay3');
+            done();
+          });
+        });
+
+        test('iron-overlay-backdrop moved to the first overlay with-backdrop', function(done) {
+          // Open them all (1, 2, then 3).
+          overlay3.opened = overlay2.opened = overlay1.opened = true;
+          // Close the first, check if backdrop is moved to overlay2.
+          runAfterClose(overlay1, function() {
+            assert.lengthOf(Polymer.dom(overlay1.root).querySelectorAll('iron-overlay-backdrop'), 0, 'not backdrop in overlay1');
+            assert.lengthOf(Polymer.dom(overlay2.root).querySelectorAll('iron-overlay-backdrop'), 1, 'backdrop moved to overlay2');
+            assert.lengthOf(Polymer.dom(overlay3.root).querySelectorAll('iron-overlay-backdrop'), 0, 'no backdrop in overlay3');
             done();
           });
         });
 
         test('iron-overlay-backdrop is removed from the DOM when all overlays with backdrop are closed', function(done) {
-          // Open & close them all.
-          overlay1.opened = true;
-          overlay2.opened = true;
-          runAfterOpen(overlay3, function() {
-            overlay1.opened = overlay2.opened = overlay3.opened = false;
-            Polymer.dom.flush();
-            assert.lengthOf(document.querySelectorAll('iron-overlay-backdrop'), 0, 'backdrop element removed from the DOM');
+          // Open them all (1, 2, then 3).
+          overlay3.opened = overlay2.opened = overlay1.opened = true;
+          // Close them all (3, 2, then 1).
+          overlay1.opened = overlay2.opened = overlay3.opened = false;
+          overlay1.addEventListener('iron-overlay-closed', function() {
+            assert.lengthOf(Polymer.dom(overlay1.root).querySelectorAll('iron-overlay-backdrop'), 0, 'no backdrop in overlay1');
+            assert.lengthOf(Polymer.dom(overlay2.root).querySelectorAll('iron-overlay-backdrop'), 0, 'no backdrop in overlay2');
+            assert.lengthOf(Polymer.dom(overlay3.root).querySelectorAll('iron-overlay-backdrop'), 0, 'no backdrop in overlay3');
             done();
-          });
-        });
-
-        test('newest overlay appear on top', function(done) {
-          runAfterOpen(overlay1, function() {
-            runAfterOpen(overlay2, function() {
-              var styleZ = parseInt(window.getComputedStyle(overlay1).zIndex, 10);
-              var style1Z = parseInt(window.getComputedStyle(overlay2).zIndex, 10);
-              var bgStyleZ = parseInt(window.getComputedStyle(overlay1.backdropElement).zIndex, 10);
-              assert.isTrue(style1Z > styleZ, 'overlay2 has higher z-index than overlay1');
-              assert.isTrue(styleZ > bgStyleZ, 'overlay1 has higher z-index than backdrop');
-              done();
-            });
           });
         });
 
@@ -1088,16 +1043,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
 
         test('updating with-backdrop updates z-index', function(done) {
-          runAfterOpen(overlay1, function() {
-            runAfterOpen(overlay2, function() {
-              overlay1.withBackdrop = false;
-              var styleZ = parseInt(window.getComputedStyle(overlay1).zIndex, 10);
-              var style1Z = parseInt(window.getComputedStyle(overlay2).zIndex, 10);
-              var bgStyleZ = parseInt(window.getComputedStyle(overlay1.backdropElement).zIndex, 10);
-              assert.isTrue(style1Z > bgStyleZ, 'overlay2 has higher z-index than backdrop');
-              assert.isTrue(styleZ < bgStyleZ, 'overlay1 has lower z-index than backdrop');
-              done();
-            });
+          overlay1.open();
+          runAfterOpen(overlay2, function() {
+            assert.equal(Polymer.dom(overlay1.backdropElement).parentNode, overlay1.root, 'backdrop in overlay1');
+            overlay1.withBackdrop = false;
+            assert.equal(Polymer.dom(overlay2.backdropElement).parentNode, overlay2.root, 'backdrop moved to overlay2');
+            done();
           });
         });
 

--- a/test/iron-overlay-behavior.html
+++ b/test/iron-overlay-behavior.html
@@ -794,6 +794,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
               assert.isFalse(Polymer.dom(overlay).deepContains(document.elementFromPoint(1, 1)), 'backdrop does NOT block interactions');
               done();
             });
+
           });
         });
 

--- a/test/test-overlay.html
+++ b/test/test-overlay.html
@@ -63,9 +63,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       _renderOpened: function() {
         if (this.animated) {
-          if (this.withBackdrop) {
-            this.backdropElement.open();
-          }
           this.classList.add('opened');
           this.fire('simple-overlay-open-animation-start');
         } else {
@@ -75,9 +72,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       _renderClosed: function() {
         if (this.animated) {
-          if (this.withBackdrop) {
-            this.backdropElement.close();
-          }
           this.classList.remove('opened');
           this.fire('simple-overlay-close-animation-start');
         } else {


### PR DESCRIPTION
Move the backdrop into the `overlay`'s root. The backdrop now is `position: absolute` and covers the whole container size, and uses `outline` to cover the rest of the screen. To block the interactions with the rest of the screen, it uses a transparent `div`. The interaction with the overlay content is still possible, as the backdrop has `z-index: -1`. 
### Cons

In `dom=shadow` this will be a breaking change, as to style the backdrop it will be necessary to have a selector on the overlay:

``` css
/* new way to style */
simple-overlay {
  --iron-overlay-backdrop-background-color: red;
}
/* old way to style */
body {
  --iron-overlay-backdrop-background-color: red;
}
```
### Pros

This provides more flexibility on styling the backdrop according to the overlay that will be opened: http://jsbin.com/sanupa/1/edit?html,output (this addresses #166)
### Notes

Adding the backdrop into an overlay's root is "better" than adding it to `document.body`, or into any other root, because it stays encapsulated into the overlay scope.

This doesn't really solve the stacking context problem: it will allow to click into the overlay content, but also to interact with the content outside the overlay (see this example http://jsbin.com/gixuki/4/edit?html,output)
