### PR TITLE
Revert of #148

### DIFF
--- a/iron-overlay-behavior.html
+++ b/iron-overlay-behavior.html
@@ -316,10 +316,15 @@ context. You should place this element as a child of `<body>` whenever possible.
         return;
       }
 
-      this._manager.addOrRemoveOverlay(this);
-
       if (this.__openChangedAsync) {
         window.cancelAnimationFrame(this.__openChangedAsync);
+      }
+
+      // Synchronously remove the overlay.
+      // The adding is done asynchronously to go out of the scope of the event
+      // which might have generated the opening.
+      if (!this.opened) {
+        this._manager.removeOverlay(this);
       }
 
       // Defer any animation-related code on attached
@@ -334,6 +339,7 @@ context. You should place this element as a child of `<body>` whenever possible.
       this.__openChangedAsync = window.requestAnimationFrame(function() {
         this.__openChangedAsync = null;
         if (this.opened) {
+          this._manager.addOverlay(this);
           this._prepareRenderOpened();
           this._renderOpened();
         } else {
@@ -356,7 +362,7 @@ context. You should place this element as a child of `<body>` whenever possible.
         this.removeAttribute('tabindex');
         this.__shouldRemoveTabIndex = false;
       }
-      if (this.opened) {
+      if (this.opened && this.isAttached) {
         this._manager.trackBackdrop();
       }
     },

--- a/iron-overlay-manager.html
+++ b/iron-overlay-manager.html
@@ -39,10 +39,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      */
     this._backdropElement = null;
 
-    // Listen to mousedown or touchstart to be sure to be the first to capture
-    // clicks outside the overlay.
-    var clickEvent = ('ontouchstart' in window) ? 'touchstart' : 'mousedown';
-    document.addEventListener(clickEvent, this._onCaptureClick.bind(this), true);
+    // Enable document-wide tap recognizer.
+    Polymer.Gestures.add(document, 'tap', null);
+    // Need to have useCapture=true, Polymer.Gestures doesn't offer that.
+    document.addEventListener('tap', this._onCaptureClick.bind(this), true);
     document.addEventListener('focus', this._onCaptureFocus.bind(this), true);
     document.addEventListener('keydown', this._onCaptureKeyDown.bind(this), true);
   };
@@ -122,7 +122,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       } else {
         this.removeOverlay(overlay);
       }
-      this.trackBackdrop();
     },
 
     /**
@@ -134,6 +133,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       var i = this._overlays.indexOf(overlay);
       if (i >= 0) {
         this._bringOverlayAtIndexToFront(i);
+        this.trackBackdrop();
         return;
       }
       var insertionIndex = this._overlays.length;
@@ -160,6 +160,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       // Get focused node.
       var element = this.deepActiveElement;
       overlay.restoreFocusNode = this._overlayParent(element) ? null : element;
+      this.trackBackdrop();
     },
 
     /**
@@ -178,6 +179,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       if (node && Polymer.dom(document.body).deepContains(node)) {
         node.focus();
       }
+      this.trackBackdrop();
     },
 
     /**
@@ -346,12 +348,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       var overlay = /** @type {?} */ (this.currentOverlay());
       // Check if clicked outside of top overlay.
       if (overlay && this._overlayInPath(Polymer.dom(event).path) !== overlay) {
-        if (overlay.withBackdrop) {
-          // There's no need to stop the propagation as the backdrop element
-          // already got this mousedown/touchstart event. Calling preventDefault
-          // on this event ensures that click/tap won't be triggered at all.
-          event.preventDefault();
-        }
         overlay._onCaptureClick(event);
       }
     },

--- a/test/iron-overlay-backdrop.html
+++ b/test/iron-overlay-backdrop.html
@@ -38,15 +38,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         }
     </style>
 
-    <style is="custom-style">
-        iron-overlay-backdrop {
-        /* For quicker tests */
-        --iron-overlay-backdrop: {
-             transition: none;
-         }
-        }
-    </style>
-
 </head>
 
 <body>
@@ -76,13 +67,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         test('backdrop size matches parent size', function(done) {
             runAfterOpen(overlay, function() {
-                Polymer.Base.async(function() {
-                    var backdrop = overlay.backdropElement;
-                    var parent = backdrop.parentElement;
-                    assert.strictEqual(backdrop.offsetWidth, parent.clientWidth, 'backdrop width matches parent width');
-                    assert.strictEqual(backdrop.offsetHeight, parent.clientHeight, 'backdrop height matches parent height');
-                    done();
-                }, 1);
+                // Flush so we are sure backdrop is added in the DOM.
+                Polymer.dom.flush();
+                var backdrop = overlay.backdropElement;
+                var parent = backdrop.parentElement;
+                assert.strictEqual(backdrop.offsetWidth, parent.clientWidth, 'backdrop width matches parent width');
+                assert.strictEqual(backdrop.offsetHeight, parent.clientHeight, 'backdrop height matches parent height');
+                done();
             });
         });
 

--- a/test/iron-overlay-behavior.html
+++ b/test/iron-overlay-behavior.html
@@ -129,11 +129,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     <script>
 
-      HTMLImports.whenReady(function() {
-        // Enable document-wide tap recognizer.
-        Polymer.Gestures.add(document, 'tap', null);
-      });
-
       function runAfterOpen(overlay, callback) {
         overlay.addEventListener('iron-overlay-opened', callback);
         overlay.open();
@@ -162,11 +157,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           var spy = sinon.spy(overlay, '_renderOpened');
           // This triggers _openedChanged.
           overlay.opened = true;
-          // Even if not attached yet, overlay should be the current overlay!
-          assert.equal(overlay, overlay._manager.currentOverlay(), 'currentOverlay ok');
           // Wait long enough for requestAnimationFrame callback.
           overlay.async(function() {
             assert.isFalse(spy.called, '_renderOpened not called');
+            // Because not attached yet, overlay should not be the current overlay!
+            assert.isNotOk(overlay._manager.currentOverlay(), 'currentOverlay not set');
             done();
           }, 100);
         });
@@ -839,11 +834,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           });
         });
 
-        test('manager.getBackdrops() immediately updated on opened changes', function() {
-          overlay.opened = true;
-          assert.equal(Polymer.IronOverlayManager.getBackdrops().length, 1, 'overlay added to manager backdrops');
-          overlay.opened = false;
-          assert.equal(Polymer.IronOverlayManager.getBackdrops().length, 0, 'overlay removed from manager backdrops');
+        test('manager.getBackdrops() updated on opened changes', function(done) {
+          runAfterOpen(overlay, function() {
+            assert.equal(Polymer.IronOverlayManager.getBackdrops().length, 1, 'overlay added to manager backdrops');
+            overlay.close();
+            assert.equal(Polymer.IronOverlayManager.getBackdrops().length, 0, 'overlay removed from manager backdrops');
+            done();
+          });
         });
 
         test('updating with-backdrop to false closes backdrop', function(done) {
@@ -857,21 +854,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         test('backdrop is removed when toggling overlay opened', function(done) {
           overlay.open();
-          assert.isOk(overlay.backdropElement.parentNode, 'backdrop is immediately inserted in the document');
           runAfterClose(overlay, function() {
             assert.isFalse(overlay.backdropElement.opened, 'backdrop is closed');
             assert.isNotOk(overlay.backdropElement.parentNode, 'backdrop is removed from document');
             done();
-          });
-        });
-
-        test('withBackdrop = true prevents click outside event', function(done) {
-          runAfterOpen(overlay, function() {
-            overlay.addEventListener('iron-overlay-canceled', function(event) {
-              assert.isTrue(event.detail.defaultPrevented, 'click event prevented');
-              done();
-            });
-            MockInteractions.tap(document.body);
           });
         });
 
@@ -948,38 +934,43 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         test('no duplicates after attached', function(done) {
           overlay1 = document.createElement('test-overlay');
-          overlay1.addEventListener('iron-overlay-opened',function() {
+          runAfterOpen(overlay1, function() {
             assert.equal(overlays.length, 1, 'correct count after open and attached');
             document.body.removeChild(overlay1);
             done();
           });
-          overlay1.opened = true;
-          assert.equal(overlays.length, 1, 'immediately updated');
           document.body.appendChild(overlay1);
         });
 
-        test('open twice handled', function() {
+        test('call open multiple times handled', function(done) {
           overlay1.open();
-          assert.equal(overlays.length, 1, '1 overlay after open');
           overlay1.open();
-          assert.equal(overlays.length, 1, '1 overlay after second open');
+          runAfterOpen(overlay1, function() {
+            assert.equal(overlays.length, 1, '1 overlay after open');
+            done();
+          })
         });
 
-        test('close handled', function() {
-          overlay1.open();
-          overlay1.close();
-          assert.equal(overlays.length, 0, '0 overlays after close');
+        test('close handled', function(done) {
+          runAfterOpen(overlay1, function() {
+            overlay1.close();
+            assert.equal(overlays.length, 0, '0 overlays after close');
+            done();
+          });
         });
 
-        test('open/close brings overlay on top', function() {
+        test('open/close brings overlay on top', function(done) {
           overlay1.open();
-          overlay2.open();
-          assert.equal(overlays.indexOf(overlay1), 0, 'overlay1 at index 0');
-          assert.equal(overlays.indexOf(overlay2), 1, 'overlay2 at index 1');
-          overlay1.close();
-          overlay1.open();
-          assert.equal(overlays.indexOf(overlay1), 1, 'overlay1 moved at index 1');
-          assert.isAbove(parseInt(overlay1.style.zIndex), parseInt(overlay2.style.zIndex), 'overlay1 on top of overlay2');
+          runAfterOpen(overlay2, function() {
+            assert.equal(overlays.indexOf(overlay1), 0, 'overlay1 at index 0');
+            assert.equal(overlays.indexOf(overlay2), 1, 'overlay2 at index 1');
+            overlay1.close();
+            runAfterOpen(overlay1, function() {
+              assert.equal(overlays.indexOf(overlay1), 1, 'overlay1 moved at index 1');
+              assert.isAbove(parseInt(overlay1.style.zIndex), parseInt(overlay2.style.zIndex), 'overlay1 on top of overlay2');
+              done();
+            });
+          });
         });
       });
 
@@ -1047,20 +1038,26 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           assert.isTrue(overlay1.backdropElement === overlay3.backdropElement, 'overlay1 and overlay3 have the same backdrop element');
         });
 
-        test('only one iron-overlay-backdrop in the DOM', function() {
+        test('only one iron-overlay-backdrop in the DOM', function(done) {
           // Open them all.
-          overlay1.opened = overlay2.opened = overlay3.opened = true;
-          assert.lengthOf(document.querySelectorAll('iron-overlay-backdrop'), 1, 'only one backdrop element in the DOM');
+          overlay1.opened = true;
+          overlay2.opened = true;
+          runAfterOpen(overlay3, function() {
+            assert.lengthOf(document.querySelectorAll('iron-overlay-backdrop'), 1, 'only one backdrop element in the DOM');
+            done();
+          });
         });
 
         test('iron-overlay-backdrop is removed from the DOM when all overlays with backdrop are closed', function(done) {
           // Open & close them all.
-          overlay1.opened = overlay2.opened = overlay3.opened = true;
-          overlay1.opened = overlay2.opened = overlay3.opened = false;
-          Polymer.Base.async(function() {
+          overlay1.opened = true;
+          overlay2.opened = true;
+          runAfterOpen(overlay3, function() {
+            overlay1.opened = overlay2.opened = overlay3.opened = false;
+            Polymer.dom.flush();
             assert.lengthOf(document.querySelectorAll('iron-overlay-backdrop'), 0, 'backdrop element removed from the DOM');
             done();
-          }, 100);
+          });
         });
 
         test('newest overlay appear on top', function(done) {


### PR DESCRIPTION
Revert #148 since it caused more issues (e.g. #174) than solving problems. Had to do this manually as #148 cannot be automatically reverted.

The whole `mousedown/touchstart` change started after I saw that some components would use `mousedown` to trigger the opening of an overlay. Instead, the manager should just listen to `tap` events, and overlays should remove themselves from the manager synchronously when they get closed, and add them asynchronously when they get opened.

If a component really has to open an overlay on `mousedown` (bad idea), it should take care the overlay doesn't get canceled by listening to `iron-overlay-canceled`, something like this http://jsbin.com/juziyow/3/edit?html,output

This also fixes #174.