### PR TITLE
Async remove overlay

### DIFF
--- a/iron-overlay-behavior.html
+++ b/iron-overlay-behavior.html
@@ -145,14 +145,6 @@ context. You should place this element as a child of `<body>` whenever possible.
       },
 
       /**
-       * Is true during the transition from close to open and open to close.
-       */
-      transitioning: {
-        type: Boolean,
-        readOnly: true
-      },
-
-      /**
        * Shortcut to access to the overlay manager.
        * @private
        * @type {Polymer.IronOverlayManagerClass}
@@ -245,6 +237,8 @@ context. You should place this element as a child of `<body>` whenever possible.
     },
 
     ready: function() {
+      // Used to skip calls to notifyResize and refit while the overlay is animating.
+      this.__isAnimating = false;
       // with-backdrop needs tabindex to be set in order to trap the focus.
       // If it is not set, IronOverlayBehavior will set it, and remove it if with-backdrop = false.
       this.__shouldRemoveTabIndex = false;
@@ -340,18 +334,25 @@ context. You should place this element as a child of `<body>` whenever possible.
         return;
       }
 
-      this._setTransitioning(true);
+      this.__isAnimating = true;
 
       // Use requestAnimationFrame for non-blocking rendering.
       this.__openedChangedRAF && window.cancelAnimationFrame(this.__openedChangedRAF);
       this.__openedChangedRAF = window.requestAnimationFrame(function() {
         this.__openedChangedRAF = null;
         if (opened) {
+          // Make overlay visible, then add it to the manager.
           this._prepareRenderOpened();
+          this._manager.addOverlay(this);
+          // Move the focus to the child node with [autofocus].
+          this._applyFocus();
+
           this._renderOpened();
         } else {
-          // Move the focus before actually closing.
+          // Remove overlay, then restore the focus before actually closing.
+          this._manager.removeOverlay(this);
           this._applyFocus();
+
           this._renderClosed();
         }
       }.bind(this));
@@ -390,12 +391,9 @@ context. You should place this element as a child of `<body>` whenever possible.
       this.refit();
       this._finishPositioning();
 
-      // Move the focus to the child node with [autofocus].
-      this._applyFocus();
-
       // Safari will apply the focus to the autofocus element when displayed
       // for the first time, so we make sure to return the focus where it was.
-      if (this.noAutoFocus) {
+      if (this.noAutoFocus && document.activeElement === this._focusNode) {
         this._focusNode.blur();
         this.__restoreFocusNode.focus();
       }
@@ -422,12 +420,8 @@ context. You should place this element as a child of `<body>` whenever possible.
      * @protected
      */
     _finishRenderOpened: function() {
-      this._manager.addOverlay(this);
-      // Focus the child node with [autofocus]
-      this._applyFocus();
-
       this.notifyResize();
-      this._setTransitioning(false);
+      this.__isAnimating = false;
 
       // Store it so we don't query too much.
       var focusableNodes = this._focusableNodes;
@@ -442,16 +436,12 @@ context. You should place this element as a child of `<body>` whenever possible.
      * @protected
      */
     _finishRenderClosed: function() {
-      this._manager.removeOverlay(this);
       // Hide the overlay.
       this.style.display = 'none';
       // Reset z-index only at the end of the animation.
       this.style.zIndex = '';
-
-      this._applyFocus();
-
       this.notifyResize();
-      this._setTransitioning(false);
+      this.__isAnimating = false;
       this.fire('iron-overlay-closed', this.closingReason);
     },
 
@@ -485,7 +475,8 @@ context. You should place this element as a child of `<body>` whenever possible.
         if (!this.noAutoFocus) {
           this._focusNode.focus();
         }
-      } else {
+      }
+      else {
         this._focusNode.blur();
         this._focusedChild = null;
         // Restore focus.
@@ -493,7 +484,13 @@ context. You should place this element as a child of `<body>` whenever possible.
           this.__restoreFocusNode.focus();
         }
         this.__restoreFocusNode = null;
-        this._manager.focusOverlay();
+        // If many overlays get closed at the same time, one of them would still
+        // be the currentOverlay even if already closed, and would call _applyFocus
+        // infinitely, so we check for this not to be the current overlay.
+        var currentOverlay = this._manager.currentOverlay();
+        if (currentOverlay && this !== currentOverlay) {
+          currentOverlay._applyFocus();
+        }
       }
     },
 
@@ -595,7 +592,7 @@ context. You should place this element as a child of `<body>` whenever possible.
         window.cancelAnimationFrame(this.__ironResizeRAF);
         this.__ironResizeRAF = null;
       }
-      if (this.opened && !this.transitioning) {
+      if (this.opened && !this.__isAnimating) {
         this.__ironResizeRAF = window.requestAnimationFrame(function() {
           this.__ironResizeRAF = null;
           this.refit();
@@ -609,7 +606,7 @@ context. You should place this element as a child of `<body>` whenever possible.
      * @protected
      */
     _onNodesChange: function() {
-      if (this.opened && !this.transitioning) {
+      if (this.opened && !this.__isAnimating) {
         this.notifyResize();
       }
     }

--- a/iron-overlay-behavior.html
+++ b/iron-overlay-behavior.html
@@ -268,12 +268,9 @@ context. You should place this element as a child of `<body>` whenever possible.
     detached: function() {
       Polymer.dom(this).unobserveNodes(this._observer);
       this._observer = null;
+      this.__openedChangedRAF && window.cancelAnimationFrame(this.__openedChangedRAF);
+      this.__openedChangedRAF = null;
       this._manager.removeOverlay(this);
-      if (this.__openedChangedRAF) {
-        window.cancelAnimationFrame(this.__openedChangedRAF);
-        this.__openedChangedRAF = null;
-      }
-      this.opened = false;
     },
 
     /**
@@ -305,9 +302,6 @@ context. You should place this element as a child of `<body>` whenever possible.
      * @param {Event=} event The original event
      */
     cancel: function(event) {
-      if (!this.opened) {
-        return;
-      }
       var cancelEvent = this.fire('iron-overlay-canceled', event, {cancelable: true});
       if (cancelEvent.defaultPrevented) {
         return;
@@ -347,26 +341,9 @@ context. You should place this element as a child of `<body>` whenever possible.
       this._setTransitioning(true);
 
       // Use requestAnimationFrame for non-blocking rendering.
-      if (this.__openedChangedRAF) {
-        window.cancelAnimationFrame(this.__openedChangedRAF);
-      }
+      this.__openedChangedRAF && window.cancelAnimationFrame(this.__openedChangedRAF);
       this.__openedChangedRAF = window.requestAnimationFrame(function() {
         this.__openedChangedRAF = null;
-        // Update the manager asynchronously, so that the triggering event that
-        // might have caused this opened change won't affect the overlay being
-        // opened/closed.
-        // Example 1: button onclick opens the overlay. This event is listened
-        // also by the manager on document.body, which checks if it happened
-        // outside the currentOverlay and cancels (closes) it if so.
-        // If this overlay becomes the current overlay synchronously, it would
-        // be the current overlay during the click outside check, hence canceled
-        // right away.
-        // Example 2: two overlays already opened, both with a button that
-        // onclick closes the overlay where is contained. If we'd update the
-        // currentOverlay synchronously, both overlays would get closed, the top
-        // one because of the direct call to close(), and the bottom one because
-        // it would be the current overlay when the manager listener is invoked.
-        this._manager.addOrRemoveOverlay(this);
         if (opened) {
           this._prepareRenderOpened();
           this._renderOpened();
@@ -440,6 +417,7 @@ context. You should place this element as a child of `<body>` whenever possible.
      * @protected
      */
     _finishRenderOpened: function() {
+      this._manager.addOverlay(this);
       // Focus the child node with [autofocus]
       this._applyFocus();
 
@@ -459,6 +437,7 @@ context. You should place this element as a child of `<body>` whenever possible.
      * @protected
      */
     _finishRenderClosed: function() {
+      this._manager.removeOverlay(this);
       // Hide the overlay.
       this.style.display = 'none';
       // Reset z-index only at the end of the animation.

--- a/iron-overlay-behavior.html
+++ b/iron-overlay-behavior.html
@@ -254,6 +254,8 @@ context. You should place this element as a child of `<body>` whenever possible.
       this.__openedChangedRAF = null;
       // Used for requestAnimationFrame when iron-resize is fired.
       this.__ironResizeRAF = null;
+      // Focused node before overlay gets opened. Can be restored on close.
+      this.__restoreFocusNode = null;
       this._ensureSetup();
     },
 
@@ -379,6 +381,8 @@ context. You should place this element as a child of `<body>` whenever possible.
      * @protected
      */
     _prepareRenderOpened: function() {
+      // Store focused node.
+      this.__restoreFocusNode = this._manager.deepActiveElement;
 
       // Needed to calculate the size of the overlay so that transitions on its size
       // will have the correct starting points.
@@ -389,10 +393,11 @@ context. You should place this element as a child of `<body>` whenever possible.
       // Move the focus to the child node with [autofocus].
       this._applyFocus();
 
-      // Safari will apply the focus to the autofocus element when displayed for the first time,
-      // so we blur it. Later, _applyFocus will set the focus if necessary.
-      if (this.noAutoFocus && document.activeElement === this._focusNode) {
+      // Safari will apply the focus to the autofocus element when displayed
+      // for the first time, so we make sure to return the focus where it was.
+      if (this.noAutoFocus) {
         this._focusNode.blur();
+        this.__restoreFocusNode.focus();
       }
     },
 
@@ -483,6 +488,11 @@ context. You should place this element as a child of `<body>` whenever possible.
       } else {
         this._focusNode.blur();
         this._focusedChild = null;
+        // Restore focus.
+        if (this.restoreFocusOnClose && this.__restoreFocusNode) {
+          this.__restoreFocusNode.focus();
+        }
+        this.__restoreFocusNode = null;
         this._manager.focusOverlay();
       }
     },

--- a/iron-overlay-behavior.html
+++ b/iron-overlay-behavior.html
@@ -263,6 +263,7 @@ context. You should place this element as a child of `<body>` whenever possible.
       Polymer.dom(this).unobserveNodes(this._observer);
       this._observer = null;
       this.opened = false;
+      this._manager.removeOverlay(this);
     },
 
     /**
@@ -328,13 +329,6 @@ context. You should place this element as a child of `<body>` whenever possible.
         window.cancelAnimationFrame(this.__openChangedAsync);
       }
 
-      // Synchronously remove the overlay.
-      // The adding is done asynchronously to go out of the scope of the event
-      // which might have generated the opening.
-      if (!this.opened) {
-        this._manager.removeOverlay(this);
-      }
-
       // Defer any animation-related code on attached
       // (_openedChanged gets called again on attached).
       if (!this.isAttached) {
@@ -346,8 +340,8 @@ context. You should place this element as a child of `<body>` whenever possible.
       // requestAnimationFrame for non-blocking rendering
       this.__openChangedAsync = window.requestAnimationFrame(function() {
         this.__openChangedAsync = null;
+        this._manager.addOrRemoveOverlay(this);
         if (this.opened) {
-          this._manager.addOverlay(this);
           this._prepareRenderOpened();
           this._renderOpened();
         } else {
@@ -420,10 +414,11 @@ context. You should place this element as a child of `<body>` whenever possible.
      * @protected
      */
     _finishRenderOpened: function() {
-
+      
       this.notifyResize();
       this.__isAnimating = false;
-
+      // Focus the child node with [autofocus]
+      this._applyFocus();
       // Store it so we don't query too much.
       var focusableNodes = this._focusableNodes;
       this.__firstFocusableNode = focusableNodes[0];
@@ -444,6 +439,7 @@ context. You should place this element as a child of `<body>` whenever possible.
 
       this.notifyResize();
       this.__isAnimating = false;
+      this._applyFocus();
       this.fire('iron-overlay-closed', this.closingReason);
     },
 
@@ -473,6 +469,13 @@ context. You should place this element as a child of `<body>` whenever possible.
      * @protected
      */
     _applyFocus: function() {
+      // We have to be careful to focus the next overlay _after_ any current
+      // transitions are complete (due to the state being toggled prior to the
+      // transition). Otherwise, we risk infinite recursion when a transitioning
+      // (closed) overlay becomes the current overlay.
+      if (this.__isAnimating) {
+        return;
+      }
       if (this.opened) {
         if (!this.noAutoFocus) {
           this._focusNode.focus();

--- a/iron-overlay-behavior.html
+++ b/iron-overlay-behavior.html
@@ -145,6 +145,14 @@ context. You should place this element as a child of `<body>` whenever possible.
       },
 
       /**
+       * Is true during the transition from close to open and open to close.
+       */
+      transitioning: {
+        type: Boolean,
+        readOnly: true
+      },
+
+      /**
        * Shortcut to access to the overlay manager.
        * @private
        * @type {Polymer.IronOverlayManagerClass}
@@ -237,24 +245,22 @@ context. You should place this element as a child of `<body>` whenever possible.
     },
 
     ready: function() {
-      // Used to skip calls to notifyResize and refit while the overlay is animating.
-      this.__isAnimating = false;
       // with-backdrop needs tabindex to be set in order to trap the focus.
       // If it is not set, IronOverlayBehavior will set it, and remove it if with-backdrop = false.
       this.__shouldRemoveTabIndex = false;
       // Used for wrapping the focus on TAB / Shift+TAB.
       this.__firstFocusableNode = this.__lastFocusableNode = null;
       // Used for requestAnimationFrame when opened changes.
-      this.__openChangedAsync = null;
+      this.__openedChangedRAF = null;
       // Used for requestAnimationFrame when iron-resize is fired.
-      this.__onIronResizeAsync = null;
+      this.__ironResizeRAF = null;
       this._ensureSetup();
     },
 
     attached: function() {
       // Call _openedChanged here so that position can be computed correctly.
       if (this.opened) {
-        this._openedChanged();
+        this._openedChanged(this.opened);
       }
       this._observer = Polymer.dom(this).observeNodes(this._onNodesChange);
     },
@@ -262,8 +268,12 @@ context. You should place this element as a child of `<body>` whenever possible.
     detached: function() {
       Polymer.dom(this).unobserveNodes(this._observer);
       this._observer = null;
-      this.opened = false;
       this._manager.removeOverlay(this);
+      if (this.__openedChangedRAF) {
+        window.cancelAnimationFrame(this.__openedChangedRAF);
+        this.__openedChangedRAF = null;
+      }
+      this.opened = false;
     },
 
     /**
@@ -295,6 +305,9 @@ context. You should place this element as a child of `<body>` whenever possible.
      * @param {Event=} event The original event
      */
     cancel: function(event) {
+      if (!this.opened) {
+        return;
+      }
       var cancelEvent = this.fire('iron-overlay-canceled', event, {cancelable: true});
       if (cancelEvent.defaultPrevented) {
         return;
@@ -313,20 +326,16 @@ context. You should place this element as a child of `<body>` whenever possible.
       this.style.display = 'none';
     },
 
-    _openedChanged: function() {
-      if (this.opened) {
+    /**
+     * Called when `opened` changes.
+     * @param {boolean=} opened
+     * @protected
+     */
+    _openedChanged: function(opened) {
+      if (opened) {
         this.removeAttribute('aria-hidden');
       } else {
         this.setAttribute('aria-hidden', 'true');
-      }
-
-      // wait to call after ready only if we're initially open
-      if (!this._overlaySetup) {
-        return;
-      }
-
-      if (this.__openChangedAsync) {
-        window.cancelAnimationFrame(this.__openChangedAsync);
       }
 
       // Defer any animation-related code on attached
@@ -335,13 +344,30 @@ context. You should place this element as a child of `<body>` whenever possible.
         return;
       }
 
-      this.__isAnimating = true;
+      this._setTransitioning(true);
 
-      // requestAnimationFrame for non-blocking rendering
-      this.__openChangedAsync = window.requestAnimationFrame(function() {
-        this.__openChangedAsync = null;
+      // Use requestAnimationFrame for non-blocking rendering.
+      if (this.__openedChangedRAF) {
+        window.cancelAnimationFrame(this.__openedChangedRAF);
+      }
+      this.__openedChangedRAF = window.requestAnimationFrame(function() {
+        this.__openedChangedRAF = null;
+        // Update the manager asynchronously, so that the triggering event that
+        // might have caused this opened change won't affect the overlay being
+        // opened/closed.
+        // Example 1: button onclick opens the overlay. This event is listened
+        // also by the manager on document.body, which checks if it happened
+        // outside the currentOverlay and cancels (closes) it if so.
+        // If this overlay becomes the current overlay synchronously, it would
+        // be the current overlay during the click outside check, hence canceled
+        // right away.
+        // Example 2: two overlays already opened, both with a button that
+        // onclick closes the overlay where is contained. If we'd update the
+        // currentOverlay synchronously, both overlays would get closed, the top
+        // one because of the direct call to close(), and the bottom one because
+        // it would be the current overlay when the manager listener is invoked.
         this._manager.addOrRemoveOverlay(this);
-        if (this.opened) {
+        if (opened) {
           this._prepareRenderOpened();
           this._renderOpened();
         } else {
@@ -414,11 +440,12 @@ context. You should place this element as a child of `<body>` whenever possible.
      * @protected
      */
     _finishRenderOpened: function() {
-      
-      this.notifyResize();
-      this.__isAnimating = false;
       // Focus the child node with [autofocus]
       this._applyFocus();
+
+      this.notifyResize();
+      this._setTransitioning(false);
+
       // Store it so we don't query too much.
       var focusableNodes = this._focusableNodes;
       this.__firstFocusableNode = focusableNodes[0];
@@ -432,14 +459,15 @@ context. You should place this element as a child of `<body>` whenever possible.
      * @protected
      */
     _finishRenderClosed: function() {
-      // Hide the overlay and remove the backdrop.
+      // Hide the overlay.
       this.style.display = 'none';
       // Reset z-index only at the end of the animation.
       this.style.zIndex = '';
 
-      this.notifyResize();
-      this.__isAnimating = false;
       this._applyFocus();
+
+      this.notifyResize();
+      this._setTransitioning(false);
       this.fire('iron-overlay-closed', this.closingReason);
     },
 
@@ -469,13 +497,6 @@ context. You should place this element as a child of `<body>` whenever possible.
      * @protected
      */
     _applyFocus: function() {
-      // We have to be careful to focus the next overlay _after_ any current
-      // transitions are complete (due to the state being toggled prior to the
-      // transition). Otherwise, we risk infinite recursion when a transitioning
-      // (closed) overlay becomes the current overlay.
-      if (this.__isAnimating) {
-        return;
-      }
       if (this.opened) {
         if (!this.noAutoFocus) {
           this._focusNode.focus();
@@ -581,13 +602,13 @@ context. You should place this element as a child of `<body>` whenever possible.
      * @protected
      */
     _onIronResize: function() {
-      if (this.__onIronResizeAsync) {
-        window.cancelAnimationFrame(this.__onIronResizeAsync);
-        this.__onIronResizeAsync = null;
+      if (this.__ironResizeRAF) {
+        window.cancelAnimationFrame(this.__ironResizeRAF);
+        this.__ironResizeRAF = null;
       }
-      if (this.opened && !this.__isAnimating) {
-        this.__onIronResizeAsync = window.requestAnimationFrame(function() {
-          this.__onIronResizeAsync = null;
+      if (this.opened && !this.transitioning) {
+        this.__ironResizeRAF = window.requestAnimationFrame(function() {
+          this.__ironResizeRAF = null;
           this.refit();
         }.bind(this));
       }
@@ -599,7 +620,7 @@ context. You should place this element as a child of `<body>` whenever possible.
      * @protected
      */
     _onNodesChange: function() {
-      if (this.opened && !this.__isAnimating) {
+      if (this.opened && !this.transitioning) {
         this.notifyResize();
       }
     }

--- a/iron-overlay-behavior.html
+++ b/iron-overlay-behavior.html
@@ -244,10 +244,8 @@ context. You should place this element as a child of `<body>` whenever possible.
       this.__shouldRemoveTabIndex = false;
       // Used for wrapping the focus on TAB / Shift+TAB.
       this.__firstFocusableNode = this.__lastFocusableNode = null;
-      // Used for requestAnimationFrame when opened changes.
-      this.__openedChangedRAF = null;
-      // Used for requestAnimationFrame when iron-resize is fired.
-      this.__ironResizeRAF = null;
+      // Used by __onNextAnimationFrame to cancel any previous callback.
+      this.__raf = null;
       // Focused node before overlay gets opened. Can be restored on close.
       this.__restoreFocusNode = null;
       this._ensureSetup();
@@ -264,8 +262,10 @@ context. You should place this element as a child of `<body>` whenever possible.
     detached: function() {
       Polymer.dom(this).unobserveNodes(this._observer);
       this._observer = null;
-      this.__openedChangedRAF && window.cancelAnimationFrame(this.__openedChangedRAF);
-      this.__openedChangedRAF = null;
+      if (this.__raf) {
+        window.cancelAnimationFrame(this.__raf);
+        this.__raf = null;
+      }
       this._manager.removeOverlay(this);
     },
 
@@ -337,25 +337,7 @@ context. You should place this element as a child of `<body>` whenever possible.
       this.__isAnimating = true;
 
       // Use requestAnimationFrame for non-blocking rendering.
-      this.__openedChangedRAF && window.cancelAnimationFrame(this.__openedChangedRAF);
-      this.__openedChangedRAF = window.requestAnimationFrame(function() {
-        this.__openedChangedRAF = null;
-        if (opened) {
-          // Make overlay visible, then add it to the manager.
-          this._prepareRenderOpened();
-          this._manager.addOverlay(this);
-          // Move the focus to the child node with [autofocus].
-          this._applyFocus();
-
-          this._renderOpened();
-        } else {
-          // Remove overlay, then restore the focus before actually closing.
-          this._manager.removeOverlay(this);
-          this._applyFocus();
-
-          this._renderClosed();
-        }
-      }.bind(this));
+      this.__onNextAnimationFrame(this.__openedChanged);
     },
 
     _canceledChanged: function() {
@@ -588,15 +570,8 @@ context. You should place this element as a child of `<body>` whenever possible.
      * @protected
      */
     _onIronResize: function() {
-      if (this.__ironResizeRAF) {
-        window.cancelAnimationFrame(this.__ironResizeRAF);
-        this.__ironResizeRAF = null;
-      }
       if (this.opened && !this.__isAnimating) {
-        this.__ironResizeRAF = window.requestAnimationFrame(function() {
-          this.__ironResizeRAF = null;
-          this.refit();
-        }.bind(this));
+        this.__onNextAnimationFrame(this.refit);
       }
     },
 
@@ -609,7 +584,50 @@ context. You should place this element as a child of `<body>` whenever possible.
       if (this.opened && !this.__isAnimating) {
         this.notifyResize();
       }
+    },
+
+    /**
+     * Tasks executed when opened changes: prepare for the opening, move the
+     * focus, update the manager, render opened/closed.
+     * @private
+     */
+    __openedChanged: function() {
+      if (this.opened) {
+        // Make overlay visible, then add it to the manager.
+        this._prepareRenderOpened();
+        this._manager.addOverlay(this);
+        // Move the focus to the child node with [autofocus].
+        this._applyFocus();
+
+        this._renderOpened();
+      } else {
+        // Remove overlay, then restore the focus before actually closing.
+        this._manager.removeOverlay(this);
+        this._applyFocus();
+
+        this._renderClosed();
+      }
+    },
+
+    /**
+     * Executes a callback on the next animation frame, overriding any previous
+     * callback awaiting for the next animation frame. e.g.
+     * `__onNextAnimationFrame(callback1) && __onNextAnimationFrame(callback2)`;
+     * `callback1` will never be invoked.
+     * @param {!Function} callback Its `this` parameter is the overlay itself.
+     * @private
+     */
+    __onNextAnimationFrame: function(callback) {
+      if (this.__raf) {
+        window.cancelAnimationFrame(this.__raf);
+      }
+      var self = this;
+      this.__raf = window.requestAnimationFrame(function nextAnimationFrame() {
+        self.__raf = null;
+        callback.call(self);
+      });
     }
+
   };
 
   /** @polymerBehavior */

--- a/iron-overlay-manager.html
+++ b/iron-overlay-manager.html
@@ -210,15 +210,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     focusOverlay: function() {
       var current = /** @type {?} */ (this.currentOverlay());
-      // We have to be careful to focus the next overlay _after_ any current
-      // transitions are complete (due to the state being toggled prior to the
-      // transition). Otherwise, we risk infinite recursion when a transitioning
-      // (closed) overlay becomes the current overlay.
-      //
-      // NOTE: We make the assumption that any overlay that completes a transition
-      // will call into focusOverlay to kick the process back off. Currently:
-      // transitionend -> _applyFocus -> focusOverlay.
-      if (current && !current.transitioning) {
+      if (current) {
         current._applyFocus();
       }
     },

--- a/iron-overlay-manager.html
+++ b/iron-overlay-manager.html
@@ -40,9 +40,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     this._backdropElement = null;
 
     // Enable document-wide tap recognizer.
-    Polymer.Gestures.add(document, 'tap', null);
-    // Need to have useCapture=true, Polymer.Gestures doesn't offer that.
-    document.addEventListener('tap', this._onCaptureClick.bind(this), true);
+    Polymer.Gestures.add(document, 'tap', this._onCaptureClick.bind(this));
+    
     document.addEventListener('focus', this._onCaptureFocus.bind(this), true);
     document.addEventListener('keydown', this._onCaptureKeyDown.bind(this), true);
   };

--- a/iron-overlay-manager.html
+++ b/iron-overlay-manager.html
@@ -200,15 +200,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     focusOverlay: function() {
       var current = /** @type {?} */ (this.currentOverlay());
-      // We have to be careful to focus the next overlay _after_ any current
-      // transitions are complete (due to the state being toggled prior to the
-      // transition). Otherwise, we risk infinite recursion when a transitioning
-      // (closed) overlay becomes the current overlay.
-      //
-      // NOTE: We make the assumption that any overlay that completes a transition
-      // will call into focusOverlay to kick the process back off. Currently:
-      // transitionend -> _applyFocus -> focusOverlay.
-      if (current && !current.transitioning) {
+      if (current) {
         current._applyFocus();
       }
     },

--- a/iron-overlay-manager.html
+++ b/iron-overlay-manager.html
@@ -156,9 +156,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
       this._overlays.splice(insertionIndex, 0, overlay);
 
-      // Get focused node.
-      var element = this.deepActiveElement;
-      overlay.restoreFocusNode = this._overlayParent(element) ? null : element;
       this.trackBackdrop();
     },
 
@@ -172,12 +169,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
       this._overlays.splice(i, 1);
 
-      var node = overlay.restoreFocusOnClose ? overlay.restoreFocusNode : null;
-      overlay.restoreFocusNode = null;
-      // Focus back only if still contained in document.body
-      if (node && Polymer.dom(document.body).deepContains(node)) {
-        node.focus();
-      }
       this.trackBackdrop();
     },
 
@@ -303,24 +294,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      */
     _applyOverlayZ: function(overlay, aboveZ) {
       this._setZ(overlay, aboveZ + 2);
-    },
-
-    /**
-     * Returns the overlay containing the provided node. If the node is an overlay,
-     * it returns the node.
-     * @param {Element=} node
-     * @return {Element|undefined}
-     * @private
-     */
-    _overlayParent: function(node) {
-      while (node && node !== document.body) {
-        // Check if it is an overlay.
-        if (node._manager === this) {
-          return node;
-        }
-        // Use logical parentNode, or native ShadowRoot host.
-        node = Polymer.dom(node).parentNode || node.host;
-      }
     },
 
     /**

--- a/iron-overlay-manager.html
+++ b/iron-overlay-manager.html
@@ -41,7 +41,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     // Enable document-wide tap recognizer.
     Polymer.Gestures.add(document, 'tap', this._onCaptureClick.bind(this));
-    
+
     document.addEventListener('focus', this._onCaptureFocus.bind(this), true);
     document.addEventListener('keydown', this._onCaptureKeyDown.bind(this), true);
   };
@@ -209,7 +209,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     focusOverlay: function() {
       var current = /** @type {?} */ (this.currentOverlay());
-      if (current) {
+      // We have to be careful to focus the next overlay _after_ any current
+      // transitions are complete (due to the state being toggled prior to the
+      // transition). Otherwise, we risk infinite recursion when a transitioning
+      // (closed) overlay becomes the current overlay.
+      //
+      // NOTE: We make the assumption that any overlay that completes a transition
+      // will call into focusOverlay to kick the process back off. Currently:
+      // transitionend -> _applyFocus -> focusOverlay.
+      if (current && !current.transitioning) {
         current._applyFocus();
       }
     },

--- a/test/iron-overlay-behavior.html
+++ b/test/iron-overlay-behavior.html
@@ -457,6 +457,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         var overlay;
 
         setup(function() {
+          // Ensure focus is set to document.body
+          document.body.focus();
           overlay = fixture('autofocus');
         });
 

--- a/test/iron-overlay-behavior.html
+++ b/test/iron-overlay-behavior.html
@@ -111,6 +111,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         </test-overlay>
         <test-overlay class="overlay-2">
           Test overlay 2
+          <button>Click</button>
         </test-overlay>
         <test-overlay2 class="overlay-3">
           Other overlay 3
@@ -1076,19 +1077,25 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           });
         });
 
-        test('click events handled only by top overlay', function(done) {
-          var btn = document.createElement('button');
-          btn.addEventListener('tap', overlay2.close.bind(overlay2));
-          Polymer.dom(overlay2).appendChild(btn);
-          runAfterOpen(overlay1, function() {
-            runAfterOpen(overlay2, function() {
-              MockInteractions.tap(btn);
-              assert.isFalse(overlay2.opened, 'overlay2 closed');
-              assert.isTrue(overlay1.opened, 'overlay1 still opened');
-              done();
+        var clickEvents = ['click', 'tap'];
+        for (var i = 0; i < clickEvents.length; i++) {
+          var eventName = clickEvents[i];
+          test(eventName + ' event handled only by top overlay', function(done) {
+            runAfterOpen(overlay1, function() {
+              runAfterOpen(overlay2, function() {
+                var btn = Polymer.dom(overlay2).querySelector('button');
+                btn.addEventListener(eventName, overlay2.close.bind(overlay2));
+                MockInteractions.tap(btn);
+                assert.isFalse(overlay2.opened, 'overlay2 closed');
+                assert.isTrue(overlay1.opened, 'overlay1 opened');
+                overlay2.addEventListener('iron-overlay-closed', function() {
+                  assert.isTrue(overlay1.opened, 'overlay1 still opened');
+                  done();
+                });
+              });
             });
           });
-        });
+        }
 
         test('updating with-backdrop updates z-index', function(done) {
           runAfterOpen(overlay1, function() {

--- a/test/iron-overlay-behavior.html
+++ b/test/iron-overlay-behavior.html
@@ -753,37 +753,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           });
         });
 
-        test('overlay does not return focus to elements contained in another overlay', function(done) {
-          var overlay2 = fixture('basic');
-          // So it doesn't interfere with focus changes.
-          overlay2.noAutoFocus = true;
-          var focusable = document.createElement('input');
-          runAfterOpen(overlay2,function () {
-            Polymer.dom(overlay2).appendChild(focusable);
-            focusable.focus();
-            runAfterOpen(overlay, function() {
-              runAfterClose(overlay, function() {
-                assert.notEqual(Polymer.IronOverlayManager.deepActiveElement, focusable, 'focus not restored to focusable inside overlay2');
-                done();
-              });
-            });
-          });
-        });
-
-        test('overlay does not return focus to elements that are not in the body anymore', function(done) {
-          var focusable = document.createElement('input');
-          document.body.appendChild(focusable);
-          focusable.focus();
-          var focusSpy = sinon.spy(focusable, 'focus');
-          runAfterOpen(overlay, function() {
-            document.body.removeChild(focusable);
-            runAfterClose(overlay, function() {
-              assert.isFalse(focusSpy.called, 'focus not called');
-              done();
-            });
-          });
-        });
-
       });
 
       suite('overlay with backdrop', function() {

--- a/test/iron-overlay-behavior.html
+++ b/test/iron-overlay-behavior.html
@@ -837,9 +837,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         test('manager.getBackdrops() updated on opened changes', function(done) {
           runAfterOpen(overlay, function() {
             assert.equal(Polymer.IronOverlayManager.getBackdrops().length, 1, 'overlay added to manager backdrops');
-            overlay.close();
-            assert.equal(Polymer.IronOverlayManager.getBackdrops().length, 0, 'overlay removed from manager backdrops');
-            done();
+            runAfterClose(overlay, function() {
+              assert.equal(Polymer.IronOverlayManager.getBackdrops().length, 0, 'overlay removed from manager backdrops');
+              done();
+            });
           });
         });
 
@@ -953,9 +954,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         test('close handled', function(done) {
           runAfterOpen(overlay1, function() {
-            overlay1.close();
-            assert.equal(overlays.length, 0, '0 overlays after close');
-            done();
+            runAfterClose(overlay1, function() {
+              assert.equal(overlays.length, 0, '0 overlays after close');
+              done();
+            });
           });
         });
 
@@ -1053,10 +1055,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           overlay1.opened = true;
           overlay2.opened = true;
           runAfterOpen(overlay3, function() {
-            overlay1.opened = overlay2.opened = overlay3.opened = false;
-            Polymer.dom.flush();
-            assert.lengthOf(document.querySelectorAll('iron-overlay-backdrop'), 0, 'backdrop element removed from the DOM');
-            done();
+            overlay1.opened = overlay2.opened = false;
+            runAfterClose(overlay3, function() {
+              assert.lengthOf(document.querySelectorAll('iron-overlay-backdrop'), 0, 'backdrop element removed from the DOM');
+              done();
+            });
           });
         });
 


### PR DESCRIPTION
Fixes #182.

This PR decouples the adding/removing of an overlay into the manager from the focus management (now delegated to the overlay).
It makes the addition/removal of the overlay into the manager asynchronous in order to skip the event that might have caused the opened change.


Since the initial implementation, the adding of the overlay to the manager was synchronous, while its removal asynchronous. In addition, each overlay would [toggle asynchronously listeners](https://github.com/PolymerElements/iron-overlay-behavior/blob/v1.0.0/iron-overlay-behavior.html#L256) for `tap` and `keydown` events. These listeners were asynchronous to **avoid the execution of the callback during the same scope of the event that triggered the open/close** (e.g. `<button onclick="overlay.open()">`). Also, the callbacks would have to check [if the element is the current overlay, or stop the event propagation](https://github.com/PolymerElements/iron-overlay-behavior/blob/v1.0.0/iron-overlay-behavior.html#L379).

This was sub-optimal when having multiple overlays opened, and lead to issues like all overlays would get closed.
The root cause of the problem was the synchronous addition of the overlay, while the listeners where toggled asynchronously. These 2 operations should instead be done together.

To solve these issues, I moved all these listeners to `IronOverlayManager`, which has visibility over who's the current overlay, and delegates the handling of the event to just one overlay (done in #116).
In that PR, the choice was to make addition and removal of the overlay **synchronous**, in order to have the manager's `currentOverlay` synchronously updated.

Instead, this operation should be **async**, as we need to avoid the callback execution during the scope of the triggering event.

That's what is being (finally) done by this PR 🎉 