### PR TITLE
use polymer v1.1.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,7 +22,7 @@
     "iron-a11y-keys-behavior": "PolymerElements/iron-a11y-keys-behavior#^1.0.0",
     "iron-fit-behavior": "PolymerElements/iron-fit-behavior#^1.0.0",
     "iron-resizable-behavior": "PolymerElements/iron-resizable-behavior#^1.0.0",
-    "polymer": "Polymer/polymer#^1.0.0"
+    "polymer": "Polymer/polymer#^1.1.0"
   },
   "devDependencies": {
     "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",


### PR DESCRIPTION
Use `polymer v1.1.0`, which contains [the commit](https://github.com/Polymer/polymer/commit/3734c4d) that ensures the support of styles inside a `template` (see `iron-overlay-backdrop`). This should have been done in #186 