### PR TITLE
remove caching of __first/lastFocusableNodes

### DIFF
--- a/iron-overlay-behavior.html
+++ b/iron-overlay-behavior.html
@@ -234,8 +234,6 @@ context. You should place this element as a child of `<body>` whenever possible.
       // with-backdrop needs tabindex to be set in order to trap the focus.
       // If it is not set, IronOverlayBehavior will set it, and remove it if with-backdrop = false.
       this.__shouldRemoveTabIndex = false;
-      // Used for wrapping the focus on TAB / Shift+TAB.
-      this.__firstFocusableNode = this.__lastFocusableNode = null;
       // Used for requestAnimationFrame when opened changes.
       this.__openChangedAsync = null;
       // Used for requestAnimationFrame when iron-resize is fired.
@@ -413,11 +411,6 @@ context. You should place this element as a child of `<body>` whenever possible.
       this.notifyResize();
       this.__isAnimating = false;
 
-      // Store it so we don't query too much.
-      var focusableNodes = this._focusableNodes;
-      this.__firstFocusableNode = focusableNodes[0];
-      this.__lastFocusableNode = focusableNodes[focusableNodes.length - 1];
-
       this.fire('iron-overlay-opened');
     },
 
@@ -528,8 +521,9 @@ context. You should place this element as a child of `<body>` whenever possible.
       // TAB wraps from last to first focusable.
       // Shift + TAB wraps from first to last focusable.
       var shift = event.shiftKey;
-      var nodeToCheck = shift ? this.__firstFocusableNode : this.__lastFocusableNode;
-      var nodeToSet = shift ? this.__lastFocusableNode : this.__firstFocusableNode;
+      var focusableNodes = this._focusableNodes;
+      var nodeToCheck = focusableNodes[shift ? 0 : focusableNodes.length - 1];
+      var nodeToSet = focusableNodes[shift ? focusableNodes.length - 1 : 0];
       var shouldWrap = false;
       if (nodeToCheck === nodeToSet) {
         // If nodeToCheck is the same as nodeToSet, it means we have an overlay

--- a/test/iron-overlay-behavior.html
+++ b/test/iron-overlay-behavior.html
@@ -660,6 +660,23 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           });
         });
 
+        test('with-backdrop: after open, update last focusable node and then Shift+TAB', function(done) {
+          overlay.withBackdrop = true;
+          var focusableNodes = overlay._focusableNodes;
+          runAfterOpen(overlay, function() {
+            // 1ms timeout needed by IE10 to have proper focus switching.
+            Polymer.Base.async(function() {
+              // Before tabbing, make lastFocusable non-tabbable. This will make
+              // the one before it (focusableNodes.length - 2), the new last focusable node.
+              focusableNodes[focusableNodes.length-1].setAttribute('tabindex', '-1');
+              // Simulate Shift+TAB.
+              MockInteractions.pressAndReleaseKeyOn(document, 9, ['shift']);
+              assert.equal(focusableNodes[focusableNodes.length-2], document.activeElement, 'focus wrapped correctly');
+              done();
+            }, 1);
+          });
+        });
+
         test('with-backdrop: Shift+TAB wrap focus in shadowDOM', function(done) {
           overlayFocusableNodes.withBackdrop = true;
           runAfterOpen(overlayFocusableNodes, function() {


### PR DESCRIPTION
Fixes https://github.com/PolymerElements/iron-overlay-behavior/issues/184 by removing the caching of `__firstFocusableNode, __lastFocusableNode`.