### PR TITLE
add iron-focusables-helper

### DIFF
--- a/iron-focusables-helper.html
+++ b/iron-focusables-helper.html
@@ -1,0 +1,135 @@
+<!doctype html>
+<!--
+@license
+Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<link rel="import" href="../polymer/polymer.html">
+
+<script>
+  (function() {
+    'use strict';
+
+    Polymer.IronFocusablesHelper = {
+
+      /**
+       * Returns a sorted array of tabbable nodes, including the root node.
+       * It searches the tabbable nodes in the light and shadow dom of the chidren,
+       * sorting the result by tabindex.
+       * @param {!Node} node
+       * @return {Array<Node>}
+       */
+      getTabbableNodes: function(node) {
+        var result = [];
+        // If there is at least one element with tabindex > 0, we need to sort
+        // the final array by tabindex.
+        var maxTabIndex = this._findTabbableNodes(node, result);
+        maxTabIndex > 0 && result.sort(this._tabIndexSort);
+        return result;
+      },
+
+      /**
+       * Returns if a node is focusable.
+       * @param {!Node} node
+       * @return {boolean}
+       */
+      isFocusable: function(node) {
+        // shadow roots won't have this method.
+        if (!node.hasAttribute) {
+          return false;
+        }
+        var name = node.localName;
+        // Elements that can be focused even if they have [disabled] attribute.
+        if (name === 'iframe' ||
+          ((name === 'a' || name === 'area') && node.hasAttribute('href')) ||
+          node.hasAttribute('tabindex') || node.hasAttribute('contentEditable')) {
+          return true;
+        }
+        // Elements that cannot be focused if they have [disabled] attribute.
+        return /^(input|select|textarea|button|object)$/.test(name) && !node.disabled;
+      },
+
+      /**
+       * Returns if a node is tabbable.
+       * @param {!Node} node
+       * @return {boolean}
+       */
+      isTabbable: function(node) {
+        return node.tabIndex >= 0 && this.isFocusable(node) && this._isVisible(node);
+      },
+
+      /**
+       * Searches for nodes that are tabbable and adds them to the `result` array.
+       * Returns the maximum tabindex of the added nodes.
+       * @param {!Node} node The starting point for the search; it's added if tabbable.
+       * @param {!Array<Node>} result
+       * @return {Number}
+       * @private
+       */
+      _findTabbableNodes: function(node, result) {
+        var maxTabIndex = 0;
+        // Skip #text nodes. If not visible, no need to explore children.
+        if (node.nodeType !== 3 && this._isVisible(node)) {
+          if (this.isTabbable(node)) {
+            result.push(node);
+            maxTabIndex = node.tabIndex;
+          }
+          var children;
+          if (node.localName === 'content') {
+            children = Polymer.dom(node).getDistributedNodes();
+          } else {
+            // Use shadow root if possible, will check for distributed nodes.
+            children = Polymer.dom(node.root || node).children;
+          }
+          for (var i = 0; i < children.length; i++) {
+            maxTabIndex = Math.max(this._findTabbableNodes(children[i], result), maxTabIndex);
+          }
+        }
+        return maxTabIndex;
+      },
+
+      /**
+       * Returns false if the node has `visibility: hidden` or `display: none`
+       * @param {!Node} node
+       * @return {boolean}
+       * @private
+       */
+      _isVisible: function(node) {
+        // Check inline style first, might save a re-flow.
+        return this._isStyleVisible(node.style) && this._isStyleVisible(window.getComputedStyle(node));
+      },
+
+      /**
+       * Returns false if the style is `visibility: hidden` or `display: none`
+       * @param {!CSSStyleDeclaration} style
+       * @return {boolean}
+       * @private
+       */
+      _isStyleVisible: function(style) {
+        return (style.visibility !== 'hidden' && style.display !== 'none');
+      },
+
+      /**
+       * Sort by tabindex. Move elements with tabindex = 0 to the end to match
+       * browser behavior, e.g. [0, 3, 1, 2] --> [1, 2, 3, 0]
+       * @param {!Node} a
+       * @param {!Node} b
+       * @return {Number}
+       * @private
+       */
+      _tabIndexSort: function(a, b) {
+        // Move tabindex = 0 elements to the end of the list.
+        if (a.tabIndex === 0 || b.tabIndex === 0) {
+          // The one with bigger `tabindex` goes on top of the list.
+          return b.tabIndex - a.tabIndex;
+        }
+        // The one with smaller `tabindex` goes on top of the list.
+        return a.tabIndex - b.tabIndex;
+      }
+    };
+  })();
+</script>

--- a/iron-focusables-helper.html
+++ b/iron-focusables-helper.html
@@ -70,7 +70,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * @return {boolean}
        */
       isTabbable: function(node) {
-        return node.tabIndex >= 0 && this.isFocusable(node) && this._isVisible(node);
+        // Check for the attribute "tabindex" instead of the element property
+        // `tabIndex` since browsers assign different values to it e.g.
+        // <div contenteditable></div> has tabIndex = -1 in FF, tabIndex = 0 in
+        // other browsers.
+        return this.isFocusable(node) && this._isVisible(node) &&
+          node.getAttribute('tabindex') !== '-1';
       },
 
       /**

--- a/iron-focusables-helper.html
+++ b/iron-focusables-helper.html
@@ -38,19 +38,30 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * @return {boolean}
        */
       isFocusable: function(node) {
+        // From http://stackoverflow.com/a/1600194/4228703:
+        // There isn't a definite list, it's up to the browser. The only
+        // standard we have is DOM Level 2 HTML https://www.w3.org/TR/DOM-Level-2-HTML/html.html,
+        // according to which the only elements that have a focus() method are
+        // HTMLInputElement,  HTMLSelectElement, HTMLTextAreaElement and
+        // HTMLAnchorElement. This notably omits HTMLButtonElement and
+        // HTMLAreaElement.
+        // Referring to these tests with focusables in different browsers
+        // http://allyjs.io/data-tables/focusable.html
+
         // shadow roots won't have this method.
         if (!node.hasAttribute) {
           return false;
         }
         var name = node.localName;
-        // Elements that can be focused even if they have [disabled] attribute.
-        if (name === 'iframe' ||
-          ((name === 'a' || name === 'area') && node.hasAttribute('href')) ||
-          node.hasAttribute('tabindex') || node.hasAttribute('contentEditable')) {
-          return true;
+        // These elements cannot be focused if they have [disabled] attribute.
+        if (/^(input|select|textarea|button|object)$/.test(name)) {
+          return !node.disabled;
         }
-        // Elements that cannot be focused if they have [disabled] attribute.
-        return /^(input|select|textarea|button|object)$/.test(name) && !node.disabled;
+        // These elements can be focused even if they have [disabled] attribute.
+        return name === 'iframe' ||
+          (/^(a|area)$/.test(name) && node.hasAttribute('href')) ||
+          node.hasAttribute('tabindex') ||
+          node.hasAttribute('contenteditable');
       },
 
       /**
@@ -99,18 +110,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * @private
        */
       _isVisible: function(node) {
-        // Check inline style first, might save a re-flow.
-        return this._isStyleVisible(node.style) && this._isStyleVisible(window.getComputedStyle(node));
-      },
-
-      /**
-       * Returns false if the style is `visibility: hidden` or `display: none`
-       * @param {!CSSStyleDeclaration} style
-       * @return {boolean}
-       * @private
-       */
-      _isStyleVisible: function(style) {
-        return (style.visibility !== 'hidden' && style.display !== 'none');
+        // Check inline style first to save a re-flow. If looks good, check also
+        // computed style.
+        if (node.style.visibility !== 'hidden' && node.style.display !== 'none') {
+          var style = window.getComputedStyle(node);
+          return (style.visibility !== 'hidden' && style.display !== 'none');
+        }
+        return false;
       },
 
       /**

--- a/iron-focusables-helper.html
+++ b/iron-focusables-helper.html
@@ -27,8 +27,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         var result = [];
         // If there is at least one element with tabindex > 0, we need to sort
         // the final array by tabindex.
-        var maxTabIndex = this._findTabbableNodes(node, result);
-        maxTabIndex > 0 && result.sort(this._tabIndexSort);
+        var needsSortByTabIndex = this._collectTabbableNodes(node, result);
+        if (needsSortByTabIndex) {
+          result.sort(this._tabIndexSort);
+        }
         return result;
       },
 
@@ -94,33 +96,44 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       /**
        * Searches for nodes that are tabbable and adds them to the `result` array.
-       * Returns the maximum tabindex of the added nodes.
-       * @param {!Node} node The starting point for the search; it's added if tabbable.
+       * Returns if the `result` array needs to be sorted by tabindex.
+       * @param {!Node} node The starting point for the search; added to `result`
+       * if tabbable.
        * @param {!Array<Node>} result
-       * @return {Number}
+       * @return {boolean}
        * @private
        */
-      _findTabbableNodes: function(node, result) {
-        var maxTabIndex = 0;
+      _collectTabbableNodes: function(node, result) {
         // Skip #text nodes. If not visible, no need to explore children.
-        if (node.nodeType !== 3 && this._isVisible(node)) {
-          var tabIndex = this._normalizedTabIndex(node);
-          if (tabIndex >= 0) {
-            result.push(node);
-            maxTabIndex = tabIndex;
-          }
-          var children;
-          if (node.localName === 'content') {
-            children = Polymer.dom(node).getDistributedNodes();
-          } else {
-            // Use shadow root if possible, will check for distributed nodes.
-            children = Polymer.dom(node.root || node).children;
-          }
-          for (var i = 0; i < children.length; i++) {
-            maxTabIndex = Math.max(this._findTabbableNodes(children[i], result), maxTabIndex);
-          }
+        if (node.nodeType === 3 || !this._isVisible(node)) {
+          return false;
         }
-        return maxTabIndex;
+        var tabIndex = this._normalizedTabIndex(node);
+
+        // TODO(valdrin) uncomment this when delegatesFocus is implemented.
+        // if delegatesFocus and tabindex = -1, should skip its children.
+        // if (tabIndex < 0 && node.delegatesFocus) {
+        //   return false;
+        // }
+
+        var needsSortByTabIndex = tabIndex > 0;
+        if (tabIndex >= 0) {
+          result.push(node);
+        }
+
+        var children;
+        if (node.localName === 'content') {
+          children = Polymer.dom(node).getDistributedNodes();
+        } else {
+          // Use shadow root if possible, will check for distributed nodes.
+          children = Polymer.dom(node.root || node).children;
+        }
+        for (var i = 0; i < children.length; i++) {
+          // Ensure method is always invoked to collect tabbable children.
+          var needsSort = this._collectTabbableNodes(children[i], result);
+          needsSortByTabIndex = needsSortByTabIndex || needsSort;
+        }
+        return needsSortByTabIndex;
       },
 
       /**

--- a/iron-focusables-helper.html
+++ b/iron-focusables-helper.html
@@ -14,6 +14,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   (function() {
     'use strict';
 
+    var p = Element.prototype;
+    var matches = p.matches || p.matchesSelector || p.mozMatchesSelector ||
+      p.msMatchesSelector || p.oMatchesSelector || p.webkitMatchesSelector;
+
     Polymer.IronFocusablesHelper = {
 
       /**
@@ -50,26 +54,25 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         // Referring to these tests with tabbables in different browsers
         // http://allyjs.io/data-tables/focusable.html
 
-        var name = element.localName;
-        // These elements cannot be focused if they have [disabled] attribute.
-        if (/^(input|select|textarea|button|object)$/.test(name)) {
-          return !element.disabled;
+        // Elements that cannot be focused if they have [disabled] attribute.
+        if (matches.call(element, 'input, select, textarea, button, object')) {
+          return matches.call(element, ':not([disabled])');
         }
-        // These elements can be focused even if they have [disabled] attribute.
-        return name === 'iframe' ||
-          (/^(a|area)$/.test(name) && element.hasAttribute('href')) ||
-          element.hasAttribute('tabindex') ||
-          element.hasAttribute('contenteditable');
+        // Elements that can be focused even if they have [disabled] attribute.
+        return matches.call(element,
+          'a[href], area[href], iframe, [tabindex], [contentEditable]');
       },
 
       /**
-       * Returns if a element is tabbable. To be tabbable, a element must be focusable
-       * and visible.
+       * Returns if a element is tabbable. To be tabbable, a element must be
+       * focusable, visible, and with a tabindex !== -1.
        * @param {!HTMLElement} element
        * @return {boolean}
        */
       isTabbable: function(element) {
-        return this._normalizedTabIndex(element) >= 0 && this._isVisible(element);
+        return this.isFocusable(element) &&
+          matches.call(element, ':not([tabindex="-1"])') &&
+          this._isVisible(element);
       },
 
       /**

--- a/iron-focusables-helper.html
+++ b/iron-focusables-helper.html
@@ -21,7 +21,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * It searches the tabbable nodes in the light and shadow dom of the chidren,
        * sorting the result by tabindex.
        * @param {!Node} node
-       * @return {Array<Node>}
+       * @return {Array<HTMLElement>}
        */
       getTabbableNodes: function(node) {
         var result = [];
@@ -35,11 +35,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       },
 
       /**
-       * Returns if a node is focusable.
-       * @param {!Node} node
+       * Returns if a element is focusable.
+       * @param {!HTMLElement} element
        * @return {boolean}
        */
-      isFocusable: function(node) {
+      isFocusable: function(element) {
         // From http://stackoverflow.com/a/1600194/4228703:
         // There isn't a definite list, it's up to the browser. The only
         // standard we have is DOM Level 2 HTML https://www.w3.org/TR/DOM-Level-2-HTML/html.html,
@@ -47,47 +47,43 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         // HTMLInputElement,  HTMLSelectElement, HTMLTextAreaElement and
         // HTMLAnchorElement. This notably omits HTMLButtonElement and
         // HTMLAreaElement.
-        // Referring to these tests with focusables in different browsers
+        // Referring to these tests with tabbables in different browsers
         // http://allyjs.io/data-tables/focusable.html
 
-        // shadow roots won't have this method.
-        if (!node.hasAttribute) {
-          return false;
-        }
-        var name = node.localName;
+        var name = element.localName;
         // These elements cannot be focused if they have [disabled] attribute.
         if (/^(input|select|textarea|button|object)$/.test(name)) {
-          return !node.disabled;
+          return !element.disabled;
         }
         // These elements can be focused even if they have [disabled] attribute.
         return name === 'iframe' ||
-          (/^(a|area)$/.test(name) && node.hasAttribute('href')) ||
-          node.hasAttribute('tabindex') ||
-          node.hasAttribute('contenteditable');
+          (/^(a|area)$/.test(name) && element.hasAttribute('href')) ||
+          element.hasAttribute('tabindex') ||
+          element.hasAttribute('contenteditable');
       },
 
       /**
-       * Returns if a node is tabbable. To be tabbable, a node must be focusable
+       * Returns if a element is tabbable. To be tabbable, a element must be focusable
        * and visible.
-       * @param {!Node} node
+       * @param {!HTMLElement} element
        * @return {boolean}
        */
-      isTabbable: function(node) {
-        return this._normalizedTabIndex(node) >= 0 && this._isVisible(node);
+      isTabbable: function(element) {
+        return this._normalizedTabIndex(element) >= 0 && this._isVisible(element);
       },
 
       /**
-       * Returns the normalized node tabindex. If not focusable, returns -1.
+       * Returns the normalized element tabindex. If not focusable, returns -1.
        * It checks for the attribute "tabindex" instead of the element property
        * `tabIndex` since browsers assign different values to it.
        * e.g. in Firefox `<div contenteditable>` has `tabIndex = -1`
-       * @param {!Node} node
+       * @param {!HTMLElement} element
        * @return {Number}
        * @private
        */
-      _normalizedTabIndex: function(node) {
-        if (this.isFocusable(node)) {
-          var tabIndex = node.getAttribute('tabindex') || 0;
+      _normalizedTabIndex: function(element) {
+        if (this.isFocusable(element)) {
+          var tabIndex = element.getAttribute('tabindex') || 0;
           return Number(tabIndex);
         }
         return -1;
@@ -98,28 +94,28 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * Returns if the `result` array needs to be sorted by tabindex.
        * @param {!Node} node The starting point for the search; added to `result`
        * if tabbable.
-       * @param {!Array<Node>} result
+       * @param {!Array<HTMLElement>} result
        * @return {boolean}
        * @private
        */
       _collectTabbableNodes: function(node, result) {
-        // Skip #text nodes. If not visible, no need to explore children.
-        if (node.nodeType === 3 || !this._isVisible(node)) {
+        // If not an element or not visible, no need to explore children.
+        if (node.nodeType !== Node.ELEMENT_NODE || !this._isVisible(node)) {
           return false;
         }
-        var tabIndex = this._normalizedTabIndex(node);
-
+        var element = /** @type {HTMLElement} */ (node);
+        var tabIndex = this._normalizedTabIndex(element);
         var needsSortByTabIndex = tabIndex > 0;
         if (tabIndex >= 0) {
-          result.push(node);
+          result.push(element);
         }
 
         var children;
-        if (node.localName === 'content') {
-          children = Polymer.dom(node).getDistributedNodes();
+        if (element.localName === 'content') {
+          children = Polymer.dom(element).getDistributedNodes();
         } else {
           // Use shadow root if possible, will check for distributed nodes.
-          children = Polymer.dom(node.root || node).children;
+          children = Polymer.dom(element.root || element).children;
         }
         for (var i = 0; i < children.length; i++) {
           // Ensure method is always invoked to collect tabbable children.
@@ -130,44 +126,46 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       },
 
       /**
-       * Returns false if the node has `visibility: hidden` or `display: none`
-       * @param {!Node} node
+       * Returns false if the element has `visibility: hidden` or `display: none`
+       * @param {!HTMLElement} element
        * @return {boolean}
        * @private
        */
-      _isVisible: function(node) {
+      _isVisible: function(element) {
         // Check inline style first to save a re-flow. If looks good, check also
         // computed style.
-        if (node.style.visibility !== 'hidden' && node.style.display !== 'none') {
-          var style = window.getComputedStyle(node);
+        var style = element.style;
+        if (style.visibility !== 'hidden' && style.display !== 'none') {
+          style = window.getComputedStyle(element);
           return (style.visibility !== 'hidden' && style.display !== 'none');
         }
         return false;
       },
 
       /**
-       * Sorts an array of nodes by tabindex. Returns a new array.
-       * @param {!Array<Node>} nodes
-       * @return {Array<Node>}
+       * Sorts an array of tabbable elements by tabindex. Returns a new array.
+       * @param {!Array<HTMLElement>} tabbables
+       * @return {Array<HTMLElement>}
        * @private
        */
-      _sortByTabIndex: function(nodes) {
+      _sortByTabIndex: function(tabbables) {
         // Implement a merge sort as Array.prototype.sort does a non-stable sort
         // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort
-        var len = nodes.length;
+        var len = tabbables.length;
         if (len < 2) {
-          return nodes;
+          return tabbables;
         }
         var pivot = Math.ceil(len / 2);
-        var left = this._sortByTabIndex(nodes.slice(0, pivot));
-        var right = this._sortByTabIndex(nodes.slice(pivot));
+        var left = this._sortByTabIndex(tabbables.slice(0, pivot));
+        var right = this._sortByTabIndex(tabbables.slice(pivot));
         return this._mergeSortByTabIndex(left, right);
       },
 
       /**
-       * @param {!Array<Node>} left
-       * @param {!Array<Node>} right
-       * @return {Array<Node>}
+       * Merge sort iterator, merges the two arrays into one, sorted by tab index.
+       * @param {!Array<HTMLElement>} left
+       * @param {!Array<HTMLElement>} right
+       * @return {Array<HTMLElement>}
        * @private
        */
       _mergeSortByTabIndex: function(left, right) {
@@ -184,13 +182,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       },
 
       /**
-       * Returns if a node has lower tab order compared to another node (both
-       * nodes are assumed to be focusable and tabbable).
+       * Returns if an element has lower tab order compared to another element
+       * (both elements are assumed to be focusable and tabbable).
        * Elements with tabindex = 0 have lower tab order compared to elements
        * with tabindex > 0.
        * If both have same tabindex, it returns false.
-       * @param {!Node} a
-       * @param {!Node} b
+       * @param {!HTMLElement} a
+       * @param {!HTMLElement} b
        * @return {boolean}
        * @private
        */

--- a/iron-focusables-helper.html
+++ b/iron-focusables-helper.html
@@ -65,17 +65,31 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       },
 
       /**
-       * Returns if a node is tabbable.
+       * Returns if a node is tabbable. To be tabbable, a node must be focusable
+       * and visible.
        * @param {!Node} node
        * @return {boolean}
        */
       isTabbable: function(node) {
-        // Check for the attribute "tabindex" instead of the element property
-        // `tabIndex` since browsers assign different values to it e.g.
-        // <div contenteditable></div> has tabIndex = -1 in FF, tabIndex = 0 in
-        // other browsers.
-        return this.isFocusable(node) && this._isVisible(node) &&
-          node.getAttribute('tabindex') !== '-1';
+        return this._normalizedTabIndex(node) >= 0 && this._isVisible(node);
+      },
+
+      /**
+       * Returns the normalized node tabindex. If not focusable, returns -1.
+       * It checks for the attribute "tabindex" instead of the element property
+       * `tabIndex` since browsers assign different values to it.
+       * e.g. for <div id="elem" contenteditable>
+       * `elem.tabIndex` is `-1` in Firefox, `0` in other browsers.
+       * @param {!Node} node
+       * @return {Number}
+       * @private
+       */
+      _normalizedTabIndex: function(node) {
+        if (this.isFocusable(node)) {
+          var tabIndex = node.getAttribute('tabindex') || 0;
+          return Number(tabIndex);
+        }
+        return -1;
       },
 
       /**
@@ -90,9 +104,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         var maxTabIndex = 0;
         // Skip #text nodes. If not visible, no need to explore children.
         if (node.nodeType !== 3 && this._isVisible(node)) {
-          if (this.isTabbable(node)) {
+          var tabIndex = this._normalizedTabIndex(node);
+          if (tabIndex >= 0) {
             result.push(node);
-            maxTabIndex = node.tabIndex;
+            maxTabIndex = tabIndex;
           }
           var children;
           if (node.localName === 'content') {

--- a/iron-focusables-helper.html
+++ b/iron-focusables-helper.html
@@ -29,7 +29,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         // the final array by tabindex.
         var needsSortByTabIndex = this._collectTabbableNodes(node, result);
         if (needsSortByTabIndex) {
-          result.sort(this._tabIndexSort);
+          return this._sortByTabIndex(result);
         }
         return result;
       },
@@ -80,8 +80,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * Returns the normalized node tabindex. If not focusable, returns -1.
        * It checks for the attribute "tabindex" instead of the element property
        * `tabIndex` since browsers assign different values to it.
-       * e.g. for <div id="elem" contenteditable>
-       * `elem.tabIndex` is `-1` in Firefox, `0` in other browsers.
+       * e.g. in Firefox `<div contenteditable>` has `tabIndex = -1`
        * @param {!Node} node
        * @return {Number}
        * @private
@@ -109,12 +108,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           return false;
         }
         var tabIndex = this._normalizedTabIndex(node);
-
-        // TODO(valdrin) uncomment this when delegatesFocus is implemented.
-        // if delegatesFocus and tabindex = -1, should skip its children.
-        // if (tabIndex < 0 && node.delegatesFocus) {
-        //   return false;
-        // }
 
         var needsSortByTabIndex = tabIndex > 0;
         if (tabIndex >= 0) {
@@ -153,21 +146,60 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       },
 
       /**
-       * Sort by tabindex. Move elements with tabindex = 0 to the end to match
-       * browser behavior, e.g. [0, 3, 1, 2] --> [1, 2, 3, 0]
-       * @param {!Node} a
-       * @param {!Node} b
-       * @return {Number}
+       * Sorts an array of nodes by tabindex. Returns a new array.
+       * @param {!Array<Node>} nodes
+       * @return {Array<Node>}
        * @private
        */
-      _tabIndexSort: function(a, b) {
-        // Move tabindex = 0 elements to the end of the list.
-        if (a.tabIndex === 0 || b.tabIndex === 0) {
-          // The one with bigger `tabindex` goes on top of the list.
-          return b.tabIndex - a.tabIndex;
+      _sortByTabIndex: function(nodes) {
+        // Implement a merge sort as Array.prototype.sort does a non-stable sort
+        // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort
+        var len = nodes.length;
+        if (len < 2) {
+          return nodes;
         }
-        // The one with smaller `tabindex` goes on top of the list.
-        return a.tabIndex - b.tabIndex;
+        var pivot = Math.ceil(len / 2);
+        var left = this._sortByTabIndex(nodes.slice(0, pivot));
+        var right = this._sortByTabIndex(nodes.slice(pivot));
+        return this._mergeSortByTabIndex(left, right);
+      },
+
+      /**
+       * @param {!Array<Node>} left
+       * @param {!Array<Node>} right
+       * @return {Array<Node>}
+       * @private
+       */
+      _mergeSortByTabIndex: function(left, right) {
+        var result = [];
+        while ((left.length > 0) && (right.length > 0)) {
+          if (this._hasLowerTabOrder(left[0], right[0])) {
+            result.push(right.shift());
+          } else {
+            result.push(left.shift());
+          }
+        }
+
+        return result.concat(left, right);
+      },
+
+      /**
+       * Returns if a node has lower tab order compared to another node (both
+       * nodes are assumed to be focusable and tabbable).
+       * Elements with tabindex = 0 have lower tab order compared to elements
+       * with tabindex > 0.
+       * If both have same tabindex, it returns false.
+       * @param {!Node} a
+       * @param {!Node} b
+       * @return {boolean}
+       * @private
+       */
+      _hasLowerTabOrder: function(a, b) {
+        // Normalize tabIndexes
+        // e.g. in Firefox `<div contenteditable>` has `tabIndex = -1`
+        var ati = Math.max(a.tabIndex, 0);
+        var bti = Math.max(b.tabIndex, 0);
+        return (ati === 0 || bti === 0) ? bti > ati : ati > bti;
       }
     };
   })();

--- a/iron-focusables-helper.html
+++ b/iron-focusables-helper.html
@@ -113,6 +113,19 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           result.push(element);
         }
 
+        // In ShadowDOM v1, tab order is affected by the order of distrubution.
+        // E.g. getTabbableNodes(#root) in ShadowDOM v1 should return [#A, #B];
+        // in ShadowDOM v0 tab order is not affected by the distrubution order,
+        // in fact getTabbableNodes(#root) returns [#B, #A].
+        //  <div id="root">
+        //   <!-- shadow -->
+        //     <slot name="a">
+        //     <slot name="b">
+        //   <!-- /shadow -->
+        //   <input id="A" slot="a">
+        //   <input id="B" slot="b" tabindex="1">
+        //  </div>
+        // TODO(valdrin) support ShadowDOM v1 when upgrading to Polymer v2.0.
         var children;
         if (element.localName === 'content') {
           children = Polymer.dom(element).getDistributedNodes();
@@ -185,7 +198,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       },
 
       /**
-       * Returns if an element has lower tab order compared to another element
+       * Returns if element `a` has lower tab order compared to element `b`
        * (both elements are assumed to be focusable and tabbable).
        * Elements with tabindex = 0 have lower tab order compared to elements
        * with tabindex > 0.

--- a/iron-overlay-behavior.html
+++ b/iron-overlay-behavior.html
@@ -12,6 +12,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="../iron-fit-behavior/iron-fit-behavior.html">
 <link rel="import" href="../iron-resizable-behavior/iron-resizable-behavior.html">
 <link rel="import" href="iron-overlay-manager.html">
+<link rel="import" href="iron-focusables-helper.html">
 
 <script>
 (function() {
@@ -195,45 +196,7 @@ context. You should place this element as a child of `<body>` whenever possible.
      * @protected
      */
     get _focusableNodes() {
-      // Elements that can be focused even if they have [disabled] attribute.
-      var FOCUSABLE_WITH_DISABLED = [
-        'a[href]',
-        'area[href]',
-        'iframe',
-        '[tabindex]',
-        '[contentEditable=true]'
-      ];
-
-      // Elements that cannot be focused if they have [disabled] attribute.
-      var FOCUSABLE_WITHOUT_DISABLED = [
-        'input',
-        'select',
-        'textarea',
-        'button'
-      ];
-
-      // Discard elements with tabindex=-1 (makes them not focusable).
-      var selector = FOCUSABLE_WITH_DISABLED.join(':not([tabindex="-1"]),') +
-        ':not([tabindex="-1"]),' +
-        FOCUSABLE_WITHOUT_DISABLED.join(':not([disabled]):not([tabindex="-1"]),') +
-        ':not([disabled]):not([tabindex="-1"])';
-
-      var focusables = Polymer.dom(this).querySelectorAll(selector);
-      if (this.tabIndex >= 0) {
-        // Insert at the beginning because we might have all elements with tabIndex = 0,
-        // and the overlay should be the first of the list.
-        focusables.splice(0, 0, this);
-      }
-      // Sort by tabindex.
-      return focusables.sort(function (a, b) {
-        if (a.tabIndex === b.tabIndex) {
-          return 0;
-        }
-        if (a.tabIndex === 0 || a.tabIndex > b.tabIndex) {
-          return 1;
-        }
-        return -1;
-      });
+      return Polymer.IronFocusablesHelper.getTabbableNodes(this);
     },
 
     ready: function() {

--- a/test/index.html
+++ b/test/index.html
@@ -23,6 +23,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       WCT.loadSuites([
         'iron-overlay-behavior.html',
         'iron-overlay-behavior.html?dom=shadow',
+        'iron-focusables-helper.html',
+        'iron-focusables-helper.html?dom=shadow',
         'iron-overlay-backdrop.html',
         'iron-overlay-backdrop.html?dom=shadow',
       ]);

--- a/test/iron-focusables-helper.html
+++ b/test/iron-focusables-helper.html
@@ -46,11 +46,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         <div>
           <input class="focusable1" placeholder="1 (nested)">
         </div>
-        <a href="#" class="focusable2">1</a>
+        <a href="#" class="focusable2">2</a>
         <button disabled> disabled button</button>
         <input disabled tabindex="0" value="disabled input with tabindex">
         <div tabindex="-1">not focusable</div>
-        <div contenteditable class="focusable3">2</div>
+        <div contenteditable class="focusable3">3</div>
       </div>
     </template>
   </test-fixture>
@@ -59,6 +59,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <template>
       <div>
         <h2>Focusables (with tabindex)</h2>
+        <div tabindex="0" class="focusable7">7</div>
+        <div tabindex="0" class="focusable8">8</div>
+        <div tabindex="0" class="focusable9">9</div>
+        <div tabindex="0" class="focusable10">10</div>
+        <div tabindex="0" class="focusable11">11</div>
+        <div tabindex="0" class="focusable12">12</div>
         <div tabindex="-1">not focusable</div>
         <div tabindex="3" class="focusable3">3</div>
         <div tabindex="4" class="focusable4">4</div>
@@ -130,13 +136,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       test('respects the tabindex order', function() {
         var node = fixture('tabindex');
         var focusableNodes = Polymer.IronFocusablesHelper.getTabbableNodes(node);
-        assert.equal(focusableNodes.length, 6, '6 nodes are focusable');
-        assert.equal(focusableNodes[0], Polymer.dom(node).querySelector('.focusable1'));
-        assert.equal(focusableNodes[1], Polymer.dom(node).querySelector('.focusable2'));
-        assert.equal(focusableNodes[2], Polymer.dom(node).querySelector('.focusable3'));
-        assert.equal(focusableNodes[3], Polymer.dom(node).querySelector('.focusable4'));
-        assert.equal(focusableNodes[4], Polymer.dom(node).querySelector('.focusable5'));
-        assert.equal(focusableNodes[5], Polymer.dom(node).querySelector('.focusable6'));
+        assert.equal(focusableNodes.length, 12, '12 nodes are focusable');
+        for (var i = 0; i < 12; i++) {
+          assert.equal(focusableNodes[i], Polymer.dom(node).querySelector('.focusable' + (i + 1)));
+        }
       });
 
       test('includes tabbable elements in the shadow dom', function() {

--- a/test/iron-focusables-helper.html
+++ b/test/iron-focusables-helper.html
@@ -46,10 +46,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         <div>
           <input class="focusable1" placeholder="1 (nested)">
         </div>
-        <button class="focusable2">1</button>
+        <a href="#" class="focusable2">1</a>
         <button disabled> disabled button</button>
+        <input disabled tabindex="0" value="disabled input with tabindex">
         <div tabindex="-1">not focusable</div>
-        <button class="focusable3">2</button>
+        <div contenteditable class="focusable3">2</div>
       </div>
     </template>
   </test-fixture>

--- a/test/iron-focusables-helper.html
+++ b/test/iron-focusables-helper.html
@@ -1,0 +1,178 @@
+<!doctype html>
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<html>
+
+<head>
+
+  <title>iron-focusables-helper tests</title>
+
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+  <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1, user-scalable=yes">
+
+  <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+
+  <script src="../../web-component-tester/browser.js"></script>
+  <link rel="import" href="../../iron-test-helpers/iron-test-helpers.html">
+  <link rel="import" href="../iron-focusables-helper.html">
+  <link rel="import" href="test-buttons.html">
+  <link rel="import" href="test-buttons-wrapper.html">
+
+  <style is="custom-style">
+    .hidden {
+      visibility: hidden;
+    }
+
+    .no-display {
+      display: none;
+    }
+  </style>
+</head>
+
+<body>
+
+  <test-fixture id="basic">
+    <template>
+      <div>
+        <h2>Focusables (no tabindex)</h2>
+        <div>
+          <input class="focusable1" placeholder="1 (nested)">
+        </div>
+        <button class="focusable2">1</button>
+        <button disabled> disabled button</button>
+        <div tabindex="-1">not focusable</div>
+        <button class="focusable3">2</button>
+      </div>
+    </template>
+  </test-fixture>
+
+  <test-fixture id="tabindex">
+    <template>
+      <div>
+        <h2>Focusables (with tabindex)</h2>
+        <div tabindex="-1">not focusable</div>
+        <div tabindex="3" class="focusable3">3</div>
+        <div tabindex="4" class="focusable4">4</div>
+        <div tabindex="5" class="focusable5">5</div>
+        <div>
+          <div tabindex="1" class="focusable1">1 (nested)</div>
+          <div tabindex="6" class="focusable6">6 (nested)</div>
+        </div>
+        <div tabindex="2" class="focusable2">2</div>
+      </div>
+    </template>
+  </test-fixture>
+
+  <test-fixture id="shadow">
+    <template>
+      <test-buttons>
+        <h2>focusables in ShadowDOM</h2>
+        <input placeholder="type something..">
+      </test-buttons>
+    </template>
+  </test-fixture>
+
+  <test-fixture id="composed">
+    <template>
+      <test-buttons-wrapper>
+        <input placeholder="type something..">
+      </test-buttons-wrapper>
+    </template>
+  </test-fixture>
+
+  <script>
+    suite('getTabbableNodes', function() {
+
+      test('returns tabbable nodes', function() {
+        var node = fixture('basic');
+        var focusableNodes = Polymer.IronFocusablesHelper.getTabbableNodes(node);
+        assert.equal(focusableNodes.length, 3, '3 nodes are focusable');
+        assert.equal(focusableNodes[0], Polymer.dom(node).querySelector('.focusable1'));
+        assert.equal(focusableNodes[1], Polymer.dom(node).querySelector('.focusable2'));
+        assert.equal(focusableNodes[2], Polymer.dom(node).querySelector('.focusable3'));
+      });
+
+      test('includes the root if it has a valid tabindex', function() {
+        var node = fixture('basic');
+        node.setAttribute('tabindex', '0');
+        var focusableNodes = Polymer.IronFocusablesHelper.getTabbableNodes(node);
+        assert.equal(focusableNodes.length, 4, '4 focusable nodes');
+        assert.notEqual(focusableNodes.indexOf(node), -1, 'root is included');
+      });
+
+      test('excludes visibility: hidden elements', function() {
+        var node = fixture('basic');
+        var focusable = Polymer.dom(node).querySelector('.focusable1');
+        focusable.classList.add('hidden');
+        var focusableNodes = Polymer.IronFocusablesHelper.getTabbableNodes(node);
+        assert.equal(focusableNodes.length, 2, '2 focusable nodes');
+        assert.equal(focusableNodes.indexOf(focusable), -1, 'hidden element is not included');
+      });
+
+      test('excludes display: none elements', function() {
+        var node = fixture('basic');
+        var focusable = Polymer.dom(node).querySelector('.focusable1');
+        focusable.classList.add('no-display');
+        var focusableNodes = Polymer.IronFocusablesHelper.getTabbableNodes(node);
+        assert.equal(focusableNodes.length, 2, '2 focusable nodes');
+        assert.equal(focusableNodes.indexOf(focusable), -1, 'hidden element is not included');
+      });
+
+      test('respects the tabindex order', function() {
+        var node = fixture('tabindex');
+        var focusableNodes = Polymer.IronFocusablesHelper.getTabbableNodes(node);
+        assert.equal(focusableNodes.length, 6, '6 nodes are focusable');
+        assert.equal(focusableNodes[0], Polymer.dom(node).querySelector('.focusable1'));
+        assert.equal(focusableNodes[1], Polymer.dom(node).querySelector('.focusable2'));
+        assert.equal(focusableNodes[2], Polymer.dom(node).querySelector('.focusable3'));
+        assert.equal(focusableNodes[3], Polymer.dom(node).querySelector('.focusable4'));
+        assert.equal(focusableNodes[4], Polymer.dom(node).querySelector('.focusable5'));
+        assert.equal(focusableNodes[5], Polymer.dom(node).querySelector('.focusable6'));
+      });
+
+      test('includes tabbable elements in the shadow dom', function() {
+        var node = fixture('shadow');
+        var focusableNodes = Polymer.IronFocusablesHelper.getTabbableNodes(node);
+        assert.equal(focusableNodes.length, 4, '4 nodes are focusable');
+        assert.equal(focusableNodes[0], node.$.button0);
+        assert.equal(focusableNodes[1], node.$.button1);
+        assert.equal(focusableNodes[2], Polymer.dom(node).querySelector('input'));
+        assert.equal(focusableNodes[3], node.$.button2);
+      });
+
+      test('handles composition', function() {
+        var node = fixture('composed');
+        var focusableNodes = Polymer.IronFocusablesHelper.getTabbableNodes(node);
+        assert.equal(focusableNodes.length, 6, '6 nodes are focusable');
+        assert.equal(focusableNodes[0], node.$.select);
+        assert.equal(focusableNodes[1], node.$.wrapped.$.button0);
+        assert.equal(focusableNodes[2], node.$.wrapped.$.button1);
+        assert.equal(focusableNodes[3], Polymer.dom(node).querySelector('input'));
+        assert.equal(focusableNodes[4], node.$.wrapped.$.button2);
+        assert.equal(focusableNodes[5], node.$.focusableDiv);
+      });
+
+      test('handles distributed nodes', function() {
+        var node = fixture('composed');
+        var wrapped = node.$.wrapped;
+        var focusableNodes = Polymer.IronFocusablesHelper.getTabbableNodes(wrapped);
+        assert.equal(focusableNodes.length, 4, '4 nodes are focusable');
+        assert.equal(focusableNodes[0], wrapped.$.button0);
+        assert.equal(focusableNodes[1], wrapped.$.button1);
+        assert.equal(focusableNodes[2], Polymer.dom(node).querySelector('input'));
+        assert.equal(focusableNodes[3], wrapped.$.button2);
+      });
+    });
+  </script>
+
+</body>
+
+</html>

--- a/test/iron-overlay-behavior.html
+++ b/test/iron-overlay-behavior.html
@@ -561,44 +561,56 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           overlayFocusableNodes = f[2];
         });
 
-        test('_focusableNodes returns nodes that are focusable', function() {
-          var focusableNodes = overlay._focusableNodes;
-          assert.equal(focusableNodes.length, 3, '3 nodes are focusable');
-          assert.equal(focusableNodes[0], Polymer.dom(overlay).querySelector('.focusable1'));
-          assert.equal(focusableNodes[1], Polymer.dom(overlay).querySelector('.focusable2'));
-          assert.equal(focusableNodes[2], Polymer.dom(overlay).querySelector('.focusable3'));
+        test('_focusableNodes returns nodes that are focusable', function(done) {
+          runAfterOpen(overlay, function() {
+            var focusableNodes = overlay._focusableNodes;
+            assert.equal(focusableNodes.length, 3, '3 nodes are focusable');
+            assert.equal(focusableNodes[0], Polymer.dom(overlay).querySelector('.focusable1'));
+            assert.equal(focusableNodes[1], Polymer.dom(overlay).querySelector('.focusable2'));
+            assert.equal(focusableNodes[2], Polymer.dom(overlay).querySelector('.focusable3'));
+            done();
+          });
         });
 
-        test('_focusableNodes includes overlay if it has a valid tabindex', function() {
-          overlay.setAttribute('tabindex', '0');
-          var focusableNodes = overlay._focusableNodes;
-          assert.equal(focusableNodes.length, 4, '4 focusable nodes');
-          assert.notEqual(focusableNodes.indexOf(overlay), -1, 'overlay is included');
+        test('_focusableNodes includes overlay if it has a valid tabindex', function(done) {
+          runAfterOpen(overlay, function() {
+            overlay.setAttribute('tabindex', '0');
+            var focusableNodes = overlay._focusableNodes;
+            assert.equal(focusableNodes.length, 4, '4 focusable nodes');
+            assert.notEqual(focusableNodes.indexOf(overlay), -1, 'overlay is included');
+            done();
+          });
         });
 
-        test('_focusableNodes respects the tabindex order', function() {
-          var focusableNodes = overlayWithTabIndex._focusableNodes;
-          assert.equal(focusableNodes.length, 6, '6 nodes are focusable');
-          assert.equal(focusableNodes[0], Polymer.dom(overlayWithTabIndex).querySelector('.focusable1'));
-          assert.equal(focusableNodes[1], Polymer.dom(overlayWithTabIndex).querySelector('.focusable2'));
-          assert.equal(focusableNodes[2], Polymer.dom(overlayWithTabIndex).querySelector('.focusable3'));
-          assert.equal(focusableNodes[3], Polymer.dom(overlayWithTabIndex).querySelector('.focusable4'));
-          assert.equal(focusableNodes[4], Polymer.dom(overlayWithTabIndex).querySelector('.focusable5'));
-          assert.equal(focusableNodes[5], Polymer.dom(overlayWithTabIndex).querySelector('.focusable6'));
+        test('_focusableNodes respects the tabindex order', function(done) {
+          runAfterOpen(overlayWithTabIndex, function() {
+            var focusableNodes = overlayWithTabIndex._focusableNodes;
+            assert.equal(focusableNodes.length, 6, '6 nodes are focusable');
+            assert.equal(focusableNodes[0], Polymer.dom(overlayWithTabIndex).querySelector('.focusable1'));
+            assert.equal(focusableNodes[1], Polymer.dom(overlayWithTabIndex).querySelector('.focusable2'));
+            assert.equal(focusableNodes[2], Polymer.dom(overlayWithTabIndex).querySelector('.focusable3'));
+            assert.equal(focusableNodes[3], Polymer.dom(overlayWithTabIndex).querySelector('.focusable4'));
+            assert.equal(focusableNodes[4], Polymer.dom(overlayWithTabIndex).querySelector('.focusable5'));
+            assert.equal(focusableNodes[5], Polymer.dom(overlayWithTabIndex).querySelector('.focusable6'));
+            done();
+          });
         });
 
-        test('_focusableNodes can be overridden', function() {
-          // It has 1 focusable in the light dom, and 2 in the shadow dom.
-          var focusableNodes = overlayFocusableNodes._focusableNodes;
-          assert.equal(focusableNodes.length, 2, 'length ok');
-          assert.equal(focusableNodes[0], overlayFocusableNodes.$.first, 'first ok');
-          assert.equal(focusableNodes[1], overlayFocusableNodes.$.last, 'last ok');
+        test('_focusableNodes can be overridden', function(done) {
+          runAfterOpen(overlayFocusableNodes, function() {
+            // It has 1 focusable in the light dom, and 2 in the shadow dom.
+            var focusableNodes = overlayFocusableNodes._focusableNodes;
+            assert.equal(focusableNodes.length, 2, 'length ok');
+            assert.equal(focusableNodes[0], overlayFocusableNodes.$.first, 'first ok');
+            assert.equal(focusableNodes[1], overlayFocusableNodes.$.last, 'last ok');
+            done();
+          });
         });
 
         test('with-backdrop: TAB & Shift+TAB wrap focus', function(done) {
           overlay.withBackdrop = true;
-          var focusableNodes = overlay._focusableNodes;
           runAfterOpen(overlay, function() {
+            var focusableNodes = overlay._focusableNodes;
             // 1ms timeout needed by IE10 to have proper focus switching.
             Polymer.Base.async(function() {
               // Go to last element.
@@ -625,8 +637,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         test('with-backdrop: TAB & Shift+TAB wrap focus respecting tabindex', function(done) {
           overlayWithTabIndex.withBackdrop = true;
-          var focusableNodes = overlayWithTabIndex._focusableNodes;
           runAfterOpen(overlayWithTabIndex, function() {
+            var focusableNodes = overlayWithTabIndex._focusableNodes;
             // 1ms timeout needed by IE10 to have proper focus switching.
             Polymer.Base.async(function() {
               // Go to last element.
@@ -644,8 +656,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         test('with-backdrop: Shift+TAB after open wrap focus', function(done) {
           overlay.withBackdrop = true;
-          var focusableNodes = overlay._focusableNodes;
           runAfterOpen(overlay, function() {
+            var focusableNodes = overlay._focusableNodes;
             // 1ms timeout needed by IE10 to have proper focus switching.
             Polymer.Base.async(function() {
               // Spy keydown.

--- a/test/iron-overlay-behavior.html
+++ b/test/iron-overlay-behavior.html
@@ -677,8 +677,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         test('with-backdrop: after open, update last focusable node and then Shift+TAB', function(done) {
           overlay.withBackdrop = true;
-          var focusableNodes = overlay._focusableNodes;
           runAfterOpen(overlay, function() {
+            var focusableNodes = overlay._focusableNodes;
             // 1ms timeout needed by IE10 to have proper focus switching.
             Polymer.Base.async(function() {
               // Before tabbing, make lastFocusable non-tabbable. This will make

--- a/test/test-buttons-wrapper.html
+++ b/test/test-buttons-wrapper.html
@@ -9,26 +9,31 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 -->
 
 <link rel="import" href="../../polymer/polymer.html">
+<link rel="import" href="test-buttons.html">
 
-<dom-module id="test-buttons">
+<dom-module id="test-buttons-wrapper">
+
+  <style>
+    :host {
+      display: block;
+      border: 1px solid gray;
+      padding: 10px;
+    }
+  </style>
+
   <template>
-    <style>
-      :host {
-        display: block;
-        border: 1px solid black;
-        padding: 10px;
-      }
-    </style>
-
-    <button id="button0">button0</button>
-    <button id="button1">button1</button>
-    <content></content>
-    <button id="button2">button2</button>
+    <select id="select">
+      <option>1</option>
+    </select>
+    <test-buttons id="wrapped">
+      <content></content>
+    </test-buttons>
+    <div tabindex="0" id="focusableDiv">Focusable div</div>
   </template>
 
   <script>
     Polymer({
-      is: 'test-buttons'
+      is: 'test-buttons-wrapper'
     });
   </script>
 </dom-module>


### PR DESCRIPTION
Fixes #196, fixes #194, fixes #192.
`iron-focusables-helper` provides `getTabbableNodes` method, used to compute the tabbable elements within a specific node, searching both in the light and shadow dom, sorting by tabindex.
`_focusableNodes` has been changed to invoke this method. Tests have been updated to look for the focusable nodes once the overlays are opened (as it is required for a node to be visible in order to be considered tabbable).
Sorting by tabindex is a stable sort ([merge sort](https://www.youtube.com/watch?v=XaqR3G_NVoo)), since `Array.prototype.sort` is not guaranteed to be stable (fixes #209).