### PR TITLE
Avoid calling `blur()` when method don't exists

### DIFF
--- a/iron-overlay-behavior.html
+++ b/iron-overlay-behavior.html
@@ -376,7 +376,8 @@ context. You should place this element as a child of `<body>` whenever possible.
       // Safari will apply the focus to the autofocus element when displayed
       // for the first time, so we make sure to return the focus where it was.
       if (this.noAutoFocus && document.activeElement === this._focusNode) {
-        this._focusNode.blur();
+        if (this._focusNode.blur)
+          this._focusNode.blur();
         this.__restoreFocusNode.focus();
       }
     },
@@ -459,7 +460,8 @@ context. You should place this element as a child of `<body>` whenever possible.
         }
       }
       else {
-        this._focusNode.blur();
+        if (this._focusNode.blur)
+          this._focusNode.blur();
         this._focusedChild = null;
         // Restore focus.
         if (this.restoreFocusOnClose && this.__restoreFocusNode) {


### PR DESCRIPTION
The internal method `_applyFocus` of [iron-overlay-behavior](https://github.com/PolymerElements/iron-overlay-behavior/blob/master/iron-overlay-behavior.html#L455) makes a call to `this._focusNode.blur();`.

When `this._focusNode` has no method "blur" defined, this causes an exception.

I just discovered that __MS Explorer 11__ and __MS Edge__ don't define any "blur" method on the `<svg>` element, so when used as a button calling `close()` on `iron-overlay` objects the process silently drops, making impossible to close the overlay.

Please check this plunk in Explorer or Edge:
https://plnkr.co/edit/rKwnv4zXFWvP9GVzPeYQ?p=preview

As yo will see, the "close" button works as expected, while the SVG blue cross fails:
(checked on SauceLabs with Windows 10 virtual machines running Explorer 11 and Edge 13)

As a workaround, I propose to modify iron-overlay-behavior, checking if `this._focusNode.blur`
exists before calling it.
