### PR TITLE
delegate tab, esc, focus, tab to correct top overlay

### DIFF
--- a/iron-overlay-behavior.html
+++ b/iron-overlay-behavior.html
@@ -406,9 +406,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      * @protected
      */
     _onCaptureClick: function(event) {
-      if (!this.noCancelOnOutsideClick) {
-        this.cancel(event);
-      }
+      this.cancel(event);
     },
 
     /**
@@ -417,9 +415,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      * @protected
      */
     _onCaptureFocus: function (event) {
-      if (!this.withBackdrop) {
-        return;
-      }
       var path = Polymer.dom(event).path;
       if (path.indexOf(this) === -1) {
         event.stopPropagation();
@@ -435,9 +430,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      * @protected
      */
     _onCaptureEsc: function(event) {
-      if (!this.noCancelOnEscKey) {
-        this.cancel(event);
-      }
+      this.cancel(event);
     },
 
     /**
@@ -447,9 +440,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      * @protected
      */
     _onCaptureTab: function(event) {
-      if (!this.withBackdrop) {
-        return;
-      }
       this.__ensureFirstLastFocusables();
       // TAB wraps from last to first focusable.
       // Shift + TAB wraps from first to last focusable.

--- a/iron-overlay-manager.html
+++ b/iron-overlay-manager.html
@@ -181,8 +181,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      * @return {Element|undefined}
      */
     currentOverlay: function() {
-      var i = this._overlays.length - 1;
-      return this._overlays[i];
+      return this._topOverlay();
     },
 
     /**
@@ -313,12 +312,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     },
 
     /**
-     * Ensures the click event is delegated to the right overlay.
+     * Delegates the click event to the right overlay.
      * @param {!Event} event
      * @private
      */
     _onCaptureClick: function(event) {
-      var overlay = /** @type {?} */ (this.currentOverlay());
+      // Get top overlay that should cancel on outside click.
+      var overlay = /** @type {?} */ (this._topOverlay(function(overlay) {
+        return !overlay.noCancelOnOutsideClick;
+      }));
       // Check if clicked outside of top overlay.
       if (overlay && this._overlayInPath(Polymer.dom(event).path) !== overlay) {
         overlay._onCaptureClick(event);
@@ -326,14 +328,47 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     },
 
     /**
-     * Ensures the focus event is delegated to the right overlay.
+     * Delegates ESC keyboard event to the right overlay.
+     * @param {!Event} event
+     * @private
+     */
+    _onCaptureEsc: function(event) {
+      // Get top overlay that should cancel on esc.
+      var overlay = /** @type {?} */ (this._topOverlay(function(overlay) {
+        return !overlay.noCancelOnEscKey;
+      }));
+      if (overlay) {
+        overlay._onCaptureEsc(event);
+      }
+    },
+
+    /**
+     * Delegates the focus event to the right overlay.
      * @param {!Event} event
      * @private
      */
     _onCaptureFocus: function(event) {
-      var overlay = /** @type {?} */ (this.currentOverlay());
+      // Get top overlay with backdrop.
+      var overlay = /** @type {?} */ (this._topOverlay(function(overlay) {
+        return overlay.withBackdrop;
+      }));
       if (overlay) {
         overlay._onCaptureFocus(event);
+      }
+    },
+
+    /**
+     * Delegates TAB keyboard event to the right overlay.
+     * @param {!Event} event
+     * @private
+     */
+    _onCaptureTab: function(event) {
+      // Get top overlay with backdrop.
+      var overlay = /** @type {?} */ (this._topOverlay(function(overlay) {
+        return overlay.withBackdrop;
+      }));
+      if (overlay) {
+        overlay._onCaptureTab(event);
       }
     },
 
@@ -343,12 +378,24 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      * @private
      */
     _onCaptureKeyDown: function(event) {
-      var overlay = /** @type {?} */ (this.currentOverlay());
-      if (overlay) {
-        if (Polymer.IronA11yKeysBehavior.keyboardEventMatchesKeys(event, 'esc')) {
-          overlay._onCaptureEsc(event);
-        } else if (Polymer.IronA11yKeysBehavior.keyboardEventMatchesKeys(event, 'tab')) {
-          overlay._onCaptureTab(event);
+      if (Polymer.IronA11yKeysBehavior.keyboardEventMatchesKeys(event, 'esc')) {
+        this._onCaptureEsc(event);
+      } else if (Polymer.IronA11yKeysBehavior.keyboardEventMatchesKeys(event, 'tab')) {
+        this._onCaptureTab(event);
+      }
+    },
+
+    /**
+     * Returns the top overlay matching the condition.
+     * @param {Function(Element)=} meetsCondition Return `true` if the passed
+     * element meets the desired condition. If null, the top element is returned.
+     * @return {Element|undefined}
+     * @private
+     */
+    _topOverlay: function(meetsCondition) {
+      for (var i = this._overlays.length - 1; i >= 0; i--) {
+        if (!meetsCondition || meetsCondition(this._overlays[i])) {
+          return this._overlays[i];
         }
       }
     },

--- a/test/iron-overlay-behavior.html
+++ b/test/iron-overlay-behavior.html
@@ -972,6 +972,41 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           });
         });
       });
+      
+      test('ESC closes only the top overlay w/o noCancelOnEscKey', function(done) {
+        overlay2.noCancelOnEscKey = true;
+        runAfterOpen(overlay1, function() {
+          runAfterOpen(overlay2, function() {
+            MockInteractions.pressAndReleaseKeyOn(document, 27);
+            assert.isFalse(overlay1.opened, 'overlay1 was closed');
+            assert.isTrue(overlay2.opened, 'overlay2 is still opened');
+            done();
+          });
+        });
+      });
+
+      test('tap closes only the top overlay', function(done) {
+        runAfterOpen(overlay1, function() {
+          runAfterOpen(overlay2, function() {
+            MockInteractions.tap(document.body);
+            assert.isFalse(overlay2.opened, 'overlay2 was closed');
+            assert.isTrue(overlay1.opened, 'overlay1 is still opened');
+            done();
+          });
+        });
+      });
+
+      test('tap closes only the top overlay w/o noCancelOnOutsideClick', function(done) {
+        overlay2.noCancelOnOutsideClick = true;
+        runAfterOpen(overlay1, function() {
+          runAfterOpen(overlay2, function() {
+            MockInteractions.tap(document.body);
+            assert.isFalse(overlay1.opened, 'overlay1 was closed');
+            assert.isTrue(overlay2.opened, 'overlay2 is still opened');
+            done();
+          });
+        });
+      });
 
       test('close an overlay in proximity to another overlay', function(done) {
         // Open and close a separate overlay.


### PR DESCRIPTION
Fixes #212 by delegating `click, esc, focus, tab` events to the correct top overlay.
- `click` -> look for top overlay with `noCancelOnOutsideClick = false`
- `esc` -> look for top overlay with `noCancelOnEscKey = false`
- `focus, tab` -> look for top overlay with `withBackdrop = true` (not required by the issue but done for completeness)
