### PR TITLE
useCapture for tap events

### DIFF
--- a/iron-overlay-manager.html
+++ b/iron-overlay-manager.html
@@ -40,8 +40,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     this._backdropElement = null;
 
     // Enable document-wide tap recognizer.
-    Polymer.Gestures.add(document, 'tap', this._onCaptureClick.bind(this));
-
+    // NOTE: Use useCapture=true to avoid accidentally prevention of the closing
+    // of an overlay via event.stopPropagation(). The only way to prevent
+    // closing of an overlay should be through its APIs.
+    Polymer.Gestures.add(document, 'tap', null);
+    document.addEventListener('tap', this._onCaptureClick.bind(this), true);
     document.addEventListener('focus', this._onCaptureFocus.bind(this), true);
     document.addEventListener('keydown', this._onCaptureKeyDown.bind(this), true);
   };

--- a/test/iron-overlay-behavior.html
+++ b/test/iron-overlay-behavior.html
@@ -428,6 +428,38 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
       });
 
+      suite('tap event listener', function() {
+        var overlay;
+
+        var preventTap = function(event) {
+          event.preventDefault();
+          event.stopPropagation();
+        };
+
+        suiteSetup(function() {
+          // Worst case scenario: listener with useCapture = true that prevents & stops propagation
+          // added before the overlay is initialized.
+          document.body.addEventListener('tap', preventTap, true);
+        });
+
+        setup(function() {
+          overlay = fixture('basic');
+        });
+
+        suiteTeardown(function() {
+          document.body.removeEventListener('tap', preventTap, true);
+        });
+
+        test('cancel an overlay with tap outside even if event is prevented by other listeners', function(done) {
+          runAfterOpen(overlay, function() {
+            overlay.addEventListener('iron-overlay-canceled', function(event) {
+              done();
+            });
+            MockInteractions.tap(document.body);
+          });
+        });
+      });
+
       suite('opened overlay', function() {
         var overlay;
 


### PR DESCRIPTION
Fixes #225 by setting `useCapture = true` to the `tap` listener.