### PR TITLE
Update iron-overlay-manager.html with document.documentElement for taps

### DIFF
--- a/iron-overlay-manager.html
+++ b/iron-overlay-manager.html
@@ -43,8 +43,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     // NOTE: Use useCapture=true to avoid accidentally prevention of the closing
     // of an overlay via event.stopPropagation(). The only way to prevent
     // closing of an overlay should be through its APIs.
+    // NOTE: enable tap on <html> to workaround Polymer/polymer#4459
     Polymer.Gestures.add(document.documentElement, 'tap', null);
-    document.documentElement.addEventListener('tap', this._onCaptureClick.bind(this), true);
+    document.addEventListener('tap', this._onCaptureClick.bind(this), true);
     document.addEventListener('focus', this._onCaptureFocus.bind(this), true);
     document.addEventListener('keydown', this._onCaptureKeyDown.bind(this), true);
   };

--- a/iron-overlay-manager.html
+++ b/iron-overlay-manager.html
@@ -43,8 +43,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     // NOTE: Use useCapture=true to avoid accidentally prevention of the closing
     // of an overlay via event.stopPropagation(). The only way to prevent
     // closing of an overlay should be through its APIs.
-    Polymer.Gestures.add(document, 'tap', null);
-    document.addEventListener('tap', this._onCaptureClick.bind(this), true);
+    Polymer.Gestures.add(document.documentElement, 'tap', null);
+    document.documentElement.addEventListener('tap', this._onCaptureClick.bind(this), true);
     document.addEventListener('focus', this._onCaptureFocus.bind(this), true);
     document.addEventListener('keydown', this._onCaptureKeyDown.bind(this), true);
   };


### PR DESCRIPTION
use document.documentElement for Gestures and tap.
fixes https://github.com/PolymerElements/iron-overlay-behavior/issues/235