### PR TITLE
[do not merge] support only ShadowDOM v1 in IronFocusablesHelper?

### DIFF
--- a/iron-focusables-helper.html
+++ b/iron-focusables-helper.html
@@ -23,14 +23,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * @return {Array<HTMLElement>}
        */
       getTabbableNodes: function(node) {
-        var tabbables = _getTabbableNodes(node);
-        return tabbables ? _getFirstLastTabbables(tabbables) : [];
+        var tabbables = _getFirstLastTabbables(node);
+        return tabbables ? _flattenFirstLastTabbables(tabbables) : [];
       }
     };
 
     var isNativeShadowDOM = !window.ShadyDOM && !!Element.prototype.attachShadow;
 
-    function _getTabbableNodes(root) {
+    function _getFirstLastTabbables(root) {
       // Handle only Element and DocumentFragments.
       if (root.nodeType !== Node.ELEMENT_NODE && root.nodeType !== Node.DOCUMENT_FRAGMENT_NODE)
         return null;
@@ -46,9 +46,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         var tabbables = [];
         for (var i = 0, l = nodes.length; i < l; i++) {
           var node = nodes[i];
-          node._tabbables = _getTabbableNodes(node);
-          // Keep reference of this node in the slot's _tabbables.
-          if (node.tabIndex >= 0 || node._tabbables) {
+          node.__firstLastTabbables = _getFirstLastTabbables(node);
+          // Keep reference of this node in the slot's __firstLastTabbables.
+          if (node.tabIndex >= 0 || node.__firstLastTabbables) {
             _updateFirstLast(node, tabbables);
           }
         }
@@ -67,23 +67,23 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       return tabbables.length ? tabbables : null;
     }
 
-    function _getFirstLastTabbables(tabbables) {
+    function _flattenFirstLastTabbables(tabbables) {
       // Get deepest first & last tabbables.
       var first = tabbables[0];
-      while (first && first._tabbables) {
-        first = first._tabbables[0];
+      while (first && first.__firstLastTabbables) {
+        first = first.__firstLastTabbables[0];
       }
       var last = tabbables[tabbables.length - 1];
-      while (last && last._tabbables) {
-        last = last._tabbables[last._tabbables.length - 1];
+      while (last && last.__firstLastTabbables) {
+        last = last.__firstLastTabbables[last.__firstLastTabbables.length - 1];
       }
       return last !== first ? [first, last] : [first];
     }
 
     function _shouldAcceptNode(element) {
       if (isNativeShadowDOM && element.shadowRoot || element.tagName === 'SLOT') {
-        element._tabbables = _getTabbableNodes(element);
-        return element._tabbables ? NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_REJECT;
+        element.__firstLastTabbables = _getFirstLastTabbables(element);
+        return element.__firstLastTabbables ? NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_REJECT;
       }
       return element.tabIndex >= 0 ? NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_SKIP;
     }
@@ -93,20 +93,19 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       // The last tabbable is the last node with tabindex 0.
       var tabIndex = Math.max(element.tabIndex, 0);
       var first = result[0];
-      var last = result[result.length - 1];
+      var last = result[1];
       if (!first) {
         // First insertion into the result.
         result.push(element);
       } else if (first.tabIndex !== 1 && tabIndex === 1) {
         // A new first!
-        result.splice(0, 0, element);
-      } else if (result.length > 1 && (tabIndex === 0 || (last.tabindex > 0 && last.tabindex < tabIndex))) {
-        // A new last!
+        result.splice(0, 1, element);
+      } else if (!last) {
+        // Second insertion into the result.
         result.push(element);
-      } else {
-        // Insert before last element.
-        // TODO(valdrin) maybe we can skipe these and not pollute the array.
-        result.splice(Math.max(result.length - 1, 1), 0, element);
+      } else if (tabIndex === 0 || (last.tabindex > 0 && last.tabindex < tabIndex)) {
+        // A new last!
+        result.splice(1, 1, element);
       }
     }
   })();

--- a/iron-focusables-helper.html
+++ b/iron-focusables-helper.html
@@ -25,10 +25,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       getTabbableNodes: function(node) {
         var tabbables = _getFirstLastTabbables(node);
         return tabbables ? _flattenFirstLastTabbables(tabbables) : [];
-      }
+      },
+      isFocusable: isFocusable,
+      isTabbable: isTabbable
     };
 
     var isNativeShadowDOM = !window.ShadyDOM && !!Element.prototype.attachShadow;
+    var p = Element.prototype;
+    var matches = p.matches || p.matchesSelector || p.mozMatchesSelector ||
+      p.msMatchesSelector || p.oMatchesSelector || p.webkitMatchesSelector;
 
     function _getFirstLastTabbables(root) {
       // Handle only Element and DocumentFragments.
@@ -46,9 +51,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         var tabbables = [];
         for (var i = 0, l = nodes.length; i < l; i++) {
           var node = nodes[i];
+          if (node.nodeType !== Node.ELEMENT_NODE) continue;
           node.__firstLastTabbables = _getFirstLastTabbables(node);
           // Keep reference of this node in the slot's __firstLastTabbables.
-          if (node.tabIndex >= 0 || node.__firstLastTabbables) {
+          if (isTabbable(node) || node.__firstLastTabbables) {
             _updateFirstLast(node, tabbables);
           }
         }
@@ -85,7 +91,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         element.__firstLastTabbables = _getFirstLastTabbables(element);
         return element.__firstLastTabbables ? NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_REJECT;
       }
-      return element.tabIndex >= 0 ? NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_SKIP;
+      return isTabbable(element) ? NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_SKIP;
     }
 
     function _updateFirstLast(element, result) {
@@ -108,5 +114,73 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         result.splice(1, 1, element);
       }
     }
+
+    /**
+     * Returns if a element is focusable.
+     * @param {!HTMLElement} element
+     * @return {boolean}
+     */
+    function isFocusable(element) {
+      // From http://stackoverflow.com/a/1600194/4228703:
+      // There isn't a definite list, it's up to the browser. The only
+      // standard we have is DOM Level 2 HTML https://www.w3.org/TR/DOM-Level-2-HTML/html.html,
+      // according to which the only elements that have a focus() method are
+      // HTMLInputElement,  HTMLSelectElement, HTMLTextAreaElement and
+      // HTMLAnchorElement. This notably omits HTMLButtonElement and
+      // HTMLAreaElement.
+      // Referring to these tests with tabbables in different browsers
+      // http://allyjs.io/data-tables/focusable.html
+
+      // Elements that cannot be focused if they have [disabled] attribute.
+      if (matches.call(element, 'input, select, textarea, button, object')) {
+        return matches.call(element, ':not([disabled])');
+      }
+      // Elements that can be focused even if they have [disabled] attribute.
+      return matches.call(element,
+        'a[href], area[href], iframe, [tabindex], [contentEditable]');
+    }
+    /**
+     * Returns false if the element has `visibility: hidden` or `display: none`
+     * @param {!HTMLElement} element
+     * @return {boolean}
+     * @private
+     */
+    function _isVisible(element) {
+      // Check inline style first to save a re-flow. If looks good, check also
+      // computed style.
+      var style = element.style;
+      if (style.visibility !== 'hidden' && style.display !== 'none') {
+        style = window.getComputedStyle(element);
+        return (style.visibility !== 'hidden' && style.display !== 'none');
+      }
+      return false;
+    }
+    /**
+     * Returns the normalized element tabindex. If not focusable, returns -1.
+     * It checks for the attribute "tabindex" instead of the element property
+     * `tabIndex` since browsers assign different values to it.
+     * e.g. in Firefox `<div contenteditable>` has `tabIndex = -1`
+     * @param {!HTMLElement} element
+     * @return {!number}
+     * @private
+     */
+    function _normalizedTabIndex(element) {
+      if (isFocusable(element) && _isVisible(element)) {
+        var tabIndex = element.getAttribute('tabindex') || 0;
+        return Number(tabIndex);
+      }
+      return -1;
+    }
+
+    /**
+     * Returns if a element is tabbable. To be tabbable, a element must be
+     * focusable, visible, and with a tabindex !== -1.
+     * @param {!HTMLElement} element
+     * @return {boolean}
+     */
+    function isTabbable(element) {
+      return _normalizedTabIndex(element) >= 0;
+    }
+
   })();
 </script>

--- a/iron-focusables-helper.html
+++ b/iron-focusables-helper.html
@@ -14,206 +14,100 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   (function() {
     'use strict';
 
-    var p = Element.prototype;
-    var matches = p.matches || p.matchesSelector || p.mozMatchesSelector ||
-      p.msMatchesSelector || p.oMatchesSelector || p.webkitMatchesSelector;
-
     Polymer.IronFocusablesHelper = {
-
       /**
-       * Returns a sorted array of tabbable nodes, including the root node.
+       * Returns the first and last tabbable nodes, excluding the root node.
        * It searches the tabbable nodes in the light and shadow dom of the chidren,
        * sorting the result by tabindex.
        * @param {!Node} node
        * @return {Array<HTMLElement>}
        */
       getTabbableNodes: function(node) {
-        var result = [];
-        // If there is at least one element with tabindex > 0, we need to sort
-        // the final array by tabindex.
-        var needsSortByTabIndex = this._collectTabbableNodes(node, result);
-        if (needsSortByTabIndex) {
-          return this._sortByTabIndex(result);
-        }
-        return result;
-      },
-
-      /**
-       * Returns if a element is focusable.
-       * @param {!HTMLElement} element
-       * @return {boolean}
-       */
-      isFocusable: function(element) {
-        // From http://stackoverflow.com/a/1600194/4228703:
-        // There isn't a definite list, it's up to the browser. The only
-        // standard we have is DOM Level 2 HTML https://www.w3.org/TR/DOM-Level-2-HTML/html.html,
-        // according to which the only elements that have a focus() method are
-        // HTMLInputElement,  HTMLSelectElement, HTMLTextAreaElement and
-        // HTMLAnchorElement. This notably omits HTMLButtonElement and
-        // HTMLAreaElement.
-        // Referring to these tests with tabbables in different browsers
-        // http://allyjs.io/data-tables/focusable.html
-
-        // Elements that cannot be focused if they have [disabled] attribute.
-        if (matches.call(element, 'input, select, textarea, button, object')) {
-          return matches.call(element, ':not([disabled])');
-        }
-        // Elements that can be focused even if they have [disabled] attribute.
-        return matches.call(element,
-          'a[href], area[href], iframe, [tabindex], [contentEditable]');
-      },
-
-      /**
-       * Returns if a element is tabbable. To be tabbable, a element must be
-       * focusable, visible, and with a tabindex !== -1.
-       * @param {!HTMLElement} element
-       * @return {boolean}
-       */
-      isTabbable: function(element) {
-        return this.isFocusable(element) &&
-          matches.call(element, ':not([tabindex="-1"])') &&
-          this._isVisible(element);
-      },
-
-      /**
-       * Returns the normalized element tabindex. If not focusable, returns -1.
-       * It checks for the attribute "tabindex" instead of the element property
-       * `tabIndex` since browsers assign different values to it.
-       * e.g. in Firefox `<div contenteditable>` has `tabIndex = -1`
-       * @param {!HTMLElement} element
-       * @return {!number}
-       * @private
-       */
-      _normalizedTabIndex: function(element) {
-        if (this.isFocusable(element)) {
-          var tabIndex = element.getAttribute('tabindex') || 0;
-          return Number(tabIndex);
-        }
-        return -1;
-      },
-
-      /**
-       * Searches for nodes that are tabbable and adds them to the `result` array.
-       * Returns if the `result` array needs to be sorted by tabindex.
-       * @param {!Node} node The starting point for the search; added to `result`
-       * if tabbable.
-       * @param {!Array<HTMLElement>} result
-       * @return {boolean}
-       * @private
-       */
-      _collectTabbableNodes: function(node, result) {
-        // If not an element or not visible, no need to explore children.
-        if (node.nodeType !== Node.ELEMENT_NODE || !this._isVisible(node)) {
-          return false;
-        }
-        var element = /** @type {HTMLElement} */ (node);
-        var tabIndex = this._normalizedTabIndex(element);
-        var needsSort = tabIndex > 0;
-        if (tabIndex >= 0) {
-          result.push(element);
-        }
-
-        // In ShadowDOM v1, tab order is affected by the order of distrubution.
-        // E.g. getTabbableNodes(#root) in ShadowDOM v1 should return [#A, #B];
-        // in ShadowDOM v0 tab order is not affected by the distrubution order,
-        // in fact getTabbableNodes(#root) returns [#B, #A].
-        //  <div id="root">
-        //   <!-- shadow -->
-        //     <slot name="a">
-        //     <slot name="b">
-        //   <!-- /shadow -->
-        //   <input id="A" slot="a">
-        //   <input id="B" slot="b" tabindex="1">
-        //  </div>
-        // TODO(valdrin) support ShadowDOM v1 when upgrading to Polymer v2.0.
-        var children;
-        if (element.localName === 'content' || element.localName === 'slot') {
-          children = Polymer.dom(element).getDistributedNodes();
-        } else {
-          // Use shadow root if possible, will check for distributed nodes.
-          children = Polymer.dom(element.root || element).children;
-        }
-        for (var i = 0; i < children.length; i++) {
-          // Ensure method is always invoked to collect tabbable children.
-          needsSort = this._collectTabbableNodes(children[i], result) || needsSort;
-        }
-        return needsSort;
-      },
-
-      /**
-       * Returns false if the element has `visibility: hidden` or `display: none`
-       * @param {!HTMLElement} element
-       * @return {boolean}
-       * @private
-       */
-      _isVisible: function(element) {
-        // Check inline style first to save a re-flow. If looks good, check also
-        // computed style.
-        var style = element.style;
-        if (style.visibility !== 'hidden' && style.display !== 'none') {
-          style = window.getComputedStyle(element);
-          return (style.visibility !== 'hidden' && style.display !== 'none');
-        }
-        return false;
-      },
-
-      /**
-       * Sorts an array of tabbable elements by tabindex. Returns a new array.
-       * @param {!Array<HTMLElement>} tabbables
-       * @return {Array<HTMLElement>}
-       * @private
-       */
-      _sortByTabIndex: function(tabbables) {
-        // Implement a merge sort as Array.prototype.sort does a non-stable sort
-        // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort
-        var len = tabbables.length;
-        if (len < 2) {
-          return tabbables;
-        }
-        var pivot = Math.ceil(len / 2);
-        var left = this._sortByTabIndex(tabbables.slice(0, pivot));
-        var right = this._sortByTabIndex(tabbables.slice(pivot));
-        return this._mergeSortByTabIndex(left, right);
-      },
-
-      /**
-       * Merge sort iterator, merges the two arrays into one, sorted by tab index.
-       * @param {!Array<HTMLElement>} left
-       * @param {!Array<HTMLElement>} right
-       * @return {Array<HTMLElement>}
-       * @private
-       */
-      _mergeSortByTabIndex: function(left, right) {
-        var result = [];
-        while ((left.length > 0) && (right.length > 0)) {
-          if (this._hasLowerTabOrder(left[0], right[0])) {
-            result.push(right.shift());
-          } else {
-            result.push(left.shift());
-          }
-        }
-
-        return result.concat(left, right);
-      },
-
-      /**
-       * Returns if element `a` has lower tab order compared to element `b`
-       * (both elements are assumed to be focusable and tabbable).
-       * Elements with tabindex = 0 have lower tab order compared to elements
-       * with tabindex > 0.
-       * If both have same tabindex, it returns false.
-       * @param {!HTMLElement} a
-       * @param {!HTMLElement} b
-       * @return {boolean}
-       * @private
-       */
-      _hasLowerTabOrder: function(a, b) {
-        // Normalize tabIndexes
-        // e.g. in Firefox `<div contenteditable>` has `tabIndex = -1`
-        var ati = Math.max(a.tabIndex, 0);
-        var bti = Math.max(b.tabIndex, 0);
-        return (ati === 0 || bti === 0) ? bti > ati : ati > bti;
+        var tabbables = _getTabbableNodes(node);
+        return tabbables ? _getFirstLastTabbables(tabbables) : [];
       }
     };
+
+    var isNativeShadowDOM = !window.ShadyDOM && !!Element.prototype.attachShadow;
+
+    function _getTabbableNodes(root) {
+      // Handle only Element and DocumentFragments.
+      if (root.nodeType !== Node.ELEMENT_NODE && root.nodeType !== Node.DOCUMENT_FRAGMENT_NODE)
+        return null;
+      // Skip all tabbables inside a shadowRoot if element has tabindex = -1.
+      if (isNativeShadowDOM && root.shadowRoot && root.getAttribute('tabindex') === '-1')
+        return null;
+
+      // Special treatment for <slot>, as we cannot use tree walkers for distributed content ;_;
+      if (isNativeShadowDOM && root.tagName === 'SLOT') {
+        var nodes = root.assignedNodes({
+          flatten: true
+        });
+        var tabbables = [];
+        for (var i = 0, l = nodes.length; i < l; i++) {
+          var node = nodes[i];
+          node._tabbables = _getTabbableNodes(node);
+          // Keep reference of this node in the slot's _tabbables.
+          if (node.tabIndex >= 0 || node._tabbables) {
+            _updateFirstLast(node, tabbables);
+          }
+        }
+        return tabbables.length ? tabbables : null;
+      }
+
+      var startNode = isNativeShadowDOM && root.shadowRoot ? root.shadowRoot : root;
+      var walker = document.createTreeWalker(startNode, NodeFilter.SHOW_ELEMENT, {
+        acceptNode: _shouldAcceptNode
+      }, false);
+
+      var tabbables = [];
+      while (walker.nextNode()) {
+        _updateFirstLast(walker.currentNode, tabbables);
+      }
+      return tabbables.length ? tabbables : null;
+    }
+
+    function _getFirstLastTabbables(tabbables) {
+      // Get deepest first & last tabbables.
+      var first = tabbables[0];
+      while (first && first._tabbables) {
+        first = first._tabbables[0];
+      }
+      var last = tabbables[tabbables.length - 1];
+      while (last && last._tabbables) {
+        last = last._tabbables[last._tabbables.length - 1];
+      }
+      return last !== first ? [first, last] : [first];
+    }
+
+    function _shouldAcceptNode(element) {
+      if (isNativeShadowDOM && element.shadowRoot || element.tagName === 'SLOT') {
+        element._tabbables = _getTabbableNodes(element);
+        return element._tabbables ? NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_REJECT;
+      }
+      return element.tabIndex >= 0 ? NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_SKIP;
+    }
+
+    function _updateFirstLast(element, result) {
+      // The first tabbable is the first node with tabindex 1 or 0.
+      // The last tabbable is the last node with tabindex 0.
+      var tabIndex = Math.max(element.tabIndex, 0);
+      var first = result[0];
+      var last = result[result.length - 1];
+      if (!first) {
+        // First insertion into the result.
+        result.push(element);
+      } else if (first.tabIndex !== 1 && tabIndex === 1) {
+        // A new first!
+        result.splice(0, 0, element);
+      } else if (result.length > 1 && (tabIndex === 0 || (last.tabindex > 0 && last.tabindex < tabIndex))) {
+        // A new last!
+        result.push(element);
+      } else {
+        // Insert before last element.
+        // TODO(valdrin) maybe we can skipe these and not pollute the array.
+        result.splice(Math.max(result.length - 1, 1), 0, element);
+      }
+    }
   })();
 </script>

--- a/iron-overlay-behavior.html
+++ b/iron-overlay-behavior.html
@@ -277,7 +277,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     _withBackdropChanged: function() {
       // If tabindex is already set, no need to override it.
       if (this.withBackdrop && !this.hasAttribute('tabindex')) {
-        this.setAttribute('tabindex', '-1');
+        this.setAttribute('tabindex', '0');
         this.__shouldRemoveTabIndex = true;
       } else if (this.__shouldRemoveTabIndex) {
         this.removeAttribute('tabindex');

--- a/iron-overlay-manager.html
+++ b/iron-overlay-manager.html
@@ -74,8 +74,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       // https://developer.mozilla.org/en-US/docs/Web/API/Document/activeElement
       // In case of null, default it to document.body.
       var active = document.activeElement || document.body;
-      while (active.root && Polymer.dom(active.root).activeElement) {
-        active = Polymer.dom(active.root).activeElement;
+      while (active.shadowRoot && active.shadowRoot.activeElement) {
+        active = active.shadowRoot.activeElement;
       }
       return active;
     },

--- a/test/iron-focusables-helper.html
+++ b/test/iron-focusables-helper.html
@@ -101,18 +101,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       test('returns tabbable nodes', function() {
         var node = fixture('basic');
         var focusableNodes = Polymer.IronFocusablesHelper.getTabbableNodes(node);
-        assert.equal(focusableNodes.length, 3, '3 nodes are focusable');
+        assert.equal(focusableNodes.length, 2);
         assert.equal(focusableNodes[0], Polymer.dom(node).querySelector('.focusable1'));
-        assert.equal(focusableNodes[1], Polymer.dom(node).querySelector('.focusable2'));
-        assert.equal(focusableNodes[2], Polymer.dom(node).querySelector('.focusable3'));
-      });
-
-      test('includes the root if it has a valid tabindex', function() {
-        var node = fixture('basic');
-        node.setAttribute('tabindex', '0');
-        var focusableNodes = Polymer.IronFocusablesHelper.getTabbableNodes(node);
-        assert.equal(focusableNodes.length, 4, '4 focusable nodes');
-        assert.notEqual(focusableNodes.indexOf(node), -1, 'root is included');
+        assert.equal(focusableNodes[1], Polymer.dom(node).querySelector('.focusable3'));
       });
 
       test('excludes visibility: hidden elements', function() {
@@ -136,43 +127,34 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       test('respects the tabindex order', function() {
         var node = fixture('tabindex');
         var focusableNodes = Polymer.IronFocusablesHelper.getTabbableNodes(node);
-        assert.equal(focusableNodes.length, 12, '12 nodes are focusable');
-        for (var i = 0; i < 12; i++) {
-          assert.equal(focusableNodes[i], Polymer.dom(node).querySelector('.focusable' + (i + 1)));
-        }
+        assert.equal(focusableNodes.length, 2);
+        assert.equal(focusableNodes[0], Polymer.dom(node).querySelector('.focusable1'));
+        assert.equal(focusableNodes[1], Polymer.dom(node).querySelector('.focusable12'));
       });
 
       test('includes tabbable elements in the shadow dom', function() {
         var node = fixture('shadow');
         var focusableNodes = Polymer.IronFocusablesHelper.getTabbableNodes(node);
-        assert.equal(focusableNodes.length, 4, '4 nodes are focusable');
+        assert.equal(focusableNodes.length, 2);
         assert.equal(focusableNodes[0], node.$.button0);
-        assert.equal(focusableNodes[1], node.$.button1);
-        assert.equal(focusableNodes[2], Polymer.dom(node).querySelector('input'));
-        assert.equal(focusableNodes[3], node.$.button2);
+        assert.equal(focusableNodes[1], node.$.button2);
       });
 
       test('handles composition', function() {
         var node = fixture('composed');
         var focusableNodes = Polymer.IronFocusablesHelper.getTabbableNodes(node);
-        assert.equal(focusableNodes.length, 6, '6 nodes are focusable');
+        assert.equal(focusableNodes.length, 2);
         assert.equal(focusableNodes[0], node.$.select);
-        assert.equal(focusableNodes[1], node.$.wrapped.$.button0);
-        assert.equal(focusableNodes[2], node.$.wrapped.$.button1);
-        assert.equal(focusableNodes[3], Polymer.dom(node).querySelector('input'));
-        assert.equal(focusableNodes[4], node.$.wrapped.$.button2);
-        assert.equal(focusableNodes[5], node.$.focusableDiv);
+        assert.equal(focusableNodes[1], node.$.focusableDiv);
       });
 
       test('handles distributed nodes', function() {
         var node = fixture('composed');
         var wrapped = node.$.wrapped;
         var focusableNodes = Polymer.IronFocusablesHelper.getTabbableNodes(wrapped);
-        assert.equal(focusableNodes.length, 4, '4 nodes are focusable');
+        assert.equal(focusableNodes.length, 2);
         assert.equal(focusableNodes[0], wrapped.$.button0);
-        assert.equal(focusableNodes[1], wrapped.$.button1);
-        assert.equal(focusableNodes[2], Polymer.dom(node).querySelector('input'));
-        assert.equal(focusableNodes[3], wrapped.$.button2);
+        assert.equal(focusableNodes[1], wrapped.$.button2);
       });
     });
   </script>

--- a/test/iron-overlay-behavior.html
+++ b/test/iron-overlay-behavior.html
@@ -618,20 +618,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       test('_focusableNodes returns nodes that are focusable', function(done) {
         runAfterOpen(overlay, function() {
           var focusableNodes = overlay._focusableNodes;
-          assert.equal(focusableNodes.length, 3, '3 nodes are focusable');
+          assert.equal(focusableNodes.length, 2);
           assert.equal(focusableNodes[0], Polymer.dom(overlay).querySelector('.focusable1'));
-          assert.equal(focusableNodes[1], Polymer.dom(overlay).querySelector('.focusable2'));
-          assert.equal(focusableNodes[2], Polymer.dom(overlay).querySelector('.focusable3'));
-          done();
-        });
-      });
-
-      test('_focusableNodes includes overlay if it has a valid tabindex', function(done) {
-        runAfterOpen(overlay, function() {
-          overlay.setAttribute('tabindex', '0');
-          var focusableNodes = overlay._focusableNodes;
-          assert.equal(focusableNodes.length, 4, '4 focusable nodes');
-          assert.notEqual(focusableNodes.indexOf(overlay), -1, 'overlay is included');
+          assert.equal(focusableNodes[1], Polymer.dom(overlay).querySelector('.focusable3'));
           done();
         });
       });
@@ -639,13 +628,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       test('_focusableNodes respects the tabindex order', function(done) {
         runAfterOpen(overlayWithTabIndex, function() {
           var focusableNodes = overlayWithTabIndex._focusableNodes;
-          assert.equal(focusableNodes.length, 6, '6 nodes are focusable');
+          assert.equal(focusableNodes.length, 2);
           assert.equal(focusableNodes[0], Polymer.dom(overlayWithTabIndex).querySelector('.focusable1'));
-          assert.equal(focusableNodes[1], Polymer.dom(overlayWithTabIndex).querySelector('.focusable2'));
-          assert.equal(focusableNodes[2], Polymer.dom(overlayWithTabIndex).querySelector('.focusable3'));
-          assert.equal(focusableNodes[3], Polymer.dom(overlayWithTabIndex).querySelector('.focusable4'));
-          assert.equal(focusableNodes[4], Polymer.dom(overlayWithTabIndex).querySelector('.focusable5'));
-          assert.equal(focusableNodes[5], Polymer.dom(overlayWithTabIndex).querySelector('.focusable6'));
+          assert.equal(focusableNodes[1], Polymer.dom(overlayWithTabIndex).querySelector('.focusable6'));
           done();
         });
       });


### PR DESCRIPTION
Change `getTabbableNodes` to return only first and last tabbable nodes.

## UPDATE
`iron-overlay-behavior` cannot support the wrapping of the focus if there are elements with `tabindex > 0`, e.g.
```html
<button id="outside">button</button>
<simple-overlay with-backdrop opened>
  <button id="mid">button</button>
  <button id="last">last tabbable</button>
  <button id="first" tabindex="1">first tabbable</button>
</simple-overlay>
```

- the document tab order is `[#first, #outside, #last, #mid]`
- `iron-focusables-helper` provides the sorted array of tabbables inside the overlay: `[#first, #last, #mid]`
- `iron-overlay-behavior` reacts on TAB keydown and checks if it should prevent the event and force focus to the first or last tabbable

If the focus is on `#first` and user presses TAB, the focus will move to `#outside`, and `iron-overlay-behavior` would know too late (after the focus moving has happened): reacting too late is overkill mainly because:
- we'd have to keep track if it was a TAB or shift + TAB
- keep track of all the sorted list of tabbables in the overlay (poorer perf)
- cannot avoid scrolling from happening when an element offscreen is focused (e.g http://jsbin.com/hohegoj/2/edit?html,output)
