### PR TITLE
Fix restore focus

### DIFF
--- a/iron-overlay-behavior.html
+++ b/iron-overlay-behavior.html
@@ -387,7 +387,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         this._focusedChild = null;
         // Restore focus.
         if (this.restoreFocusOnClose && this.__restoreFocusNode) {
-          this.__restoreFocusNode.focus();
+          // If the activeElement is `<body>` or inside the overlay,
+          // we are allowed to restore the focus. In all the other
+          // cases focus might have been moved elsewhere by another
+          // component or by an user interaction (e.g. click on a
+          // button outside the overlay).
+          var activeElement = this._manager.deepActiveElement;
+          if (activeElement === document.body ||
+            Polymer.dom(this).deepContains(activeElement)) {
+            this.__restoreFocusNode.focus();
+          }
         }
         this.__restoreFocusNode = null;
         // If many overlays get closed at the same time, one of them would still

--- a/test/iron-overlay-behavior.html
+++ b/test/iron-overlay-behavior.html
@@ -847,6 +847,20 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
       });
 
+      test('avoids restoring focus if focus changed', function(done) {
+        var button0 = document.getElementById('buttons').$.button0;
+        var button1 = document.getElementById('buttons').$.button1;
+        button0.focus();
+        runAfterOpen(overlay, function() {
+          button1.focus();
+          runAfterClose(overlay, function() {
+            assert.equal(Polymer.IronOverlayManager.deepActiveElement, button1,
+              'focus was not modified');
+            done();
+          });
+        });
+      });
+
     });
 
     suite('overlay with backdrop', function() {


### PR DESCRIPTION
Restore focus only if activeElement was not changed by user interaction or other components.

Fixes https://github.com/PolymerElements/paper-dialog/issues/146