### PR TITLE
allow-click-through

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -275,6 +275,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </template>
   </demo-snippet>
 
+  <h3>Use <code>allow-click-through</code> to allow click events to be handled by overlays below the top overlay.</h3>
+  <demo-snippet>
+    <template>
+      <button onclick="plain.open();toast.open()">Overlay that allows click through</button>
+      <simple-overlay id="toast" allow-click-through no-cancel-on-outside-click horizontal-align="left" vertical-align="bottom" no-auto-focus>
+        <span>This overlay allows click-through which can close overlays below it.</span>
+        <button onclick="toast.close()">Close</button>
+      </simple-overlay>
+    </template>
+  </demo-snippet>
+
 </body>
 
 </html>

--- a/iron-overlay-behavior.html
+++ b/iron-overlay-behavior.html
@@ -97,6 +97,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       },
 
       /**
+       * Set to true to allow clicks to go through overlays. 
+       * When the user clicks outside this overlay, the click may
+       * close the overlay below.
+       */
+      allowClickThrough: {
+        type: Boolean
+      },
+
+      /**
        * Set to true to keep overlay always on top.
        */
       alwaysOnTop: {

--- a/iron-overlay-manager.html
+++ b/iron-overlay-manager.html
@@ -318,10 +318,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      * @private
      */
     _onCaptureClick: function(event) {
-      var overlay = /** @type {?} */ (this.currentOverlay());
-      // Check if clicked outside of top overlay.
-      if (overlay && this._overlayInPath(Polymer.dom(event).path) !== overlay) {
+      var i = this._overlays.length - 1;
+      if (i === -1) return;
+      var path = Polymer.dom(event).path;
+      var overlay;
+      // Check if clicked outside of overlay.
+      while ((overlay = /** @type {?} */ (this._overlays[i])) && this._overlayInPath(path) !== overlay) {
         overlay._onCaptureClick(event);
+        if (overlay.allowClickThrough) {
+          i--;
+        } else {
+          break;
+        }
       }
     },
 

--- a/test/iron-overlay-behavior.html
+++ b/test/iron-overlay-behavior.html
@@ -988,6 +988,31 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         })
       });
 
+      test('allow-click-through allows overlay below to handle click', function(done) {
+        overlay2.allowClickThrough = true;
+        runAfterOpen(overlay1, function() {
+          runAfterOpen(overlay2, function() {
+            MockInteractions.tap(document.body);
+            assert.isFalse(overlay1.opened, 'overlay1 was closed');
+            assert.isFalse(overlay2.opened, 'overlay2 was closed');
+            done();
+          });
+        });
+      });
+
+      test('allow-click-through and no-cancel-on-outside-click combo', function(done) {
+        overlay2.allowClickThrough = true;
+        overlay2.noCancelOnOutsideClick = true;
+        runAfterOpen(overlay1, function() {
+          runAfterOpen(overlay2, function() {
+            MockInteractions.tap(document.body);
+            assert.isTrue(overlay2.opened, 'overlay2 still open');
+            assert.isFalse(overlay1.opened, 'overlay1 was closed');
+            done();
+          });
+        });
+      });
+
     });
 
     suite('Manager overlays in sync', function() {


### PR DESCRIPTION
Fixes #212.
`allow-click-through` property can be used to let click events go through overlays.
An overlay with `noCancelOnOutsideClick` would handle the click by not closing when the user clicks outside, while at the same time allow the overlay below it to handle the click (which might close if it's `noCancelOnOutsideClick = false`).

A concrete example is `paper-toast`, which should not close on click outside, but at the same time should allow overlays below it to close on outside click. 