### PR TITLE
backdrop z-index below top overlay with-backdrop

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -90,14 +90,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <demo-snippet>
     <template>
       <button onclick="multiple.open()">Open first overlay</button>
-      <simple-overlay id="multiple" tabindex=-1>
+      <simple-overlay id="multiple" tabindex=-1 with-backdrop>
         <p>click to open another overlay</p>
         <button onclick="multiple2.open()">Open second overlay</button>
         <button onclick="multiple.close()">Close this</button>
       </simple-overlay>
-      <simple-overlay id="multiple2" tabindex=-1>
-        <h2>Hi!</h2>
+      <simple-overlay id="multiple2" tabindex=-1 with-backdrop>
+        <button onclick="multiple3.open()">Open third overlay</button>
         <button onclick="multiple2.close()">Close</button>
+      </simple-overlay>
+      <simple-overlay id="multiple3" tabindex=-1>
+        <h2>Hello!</h2>
+        <button onclick="multiple3.close()">Close</button>
       </simple-overlay>
     </template>
   </demo-snippet>

--- a/iron-overlay-manager.html
+++ b/iron-overlay-manager.html
@@ -258,7 +258,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      * @private
      */
     _overlayWithBackdrop: function() {
-      for (var i = 0; i < this._overlays.length; i++) {
+      for (var i = this._overlays.length - 1; i >= 0; i--) {
         if (this._overlays[i].withBackdrop) {
           return this._overlays[i];
         }

--- a/test/iron-overlay-behavior.html
+++ b/test/iron-overlay-behavior.html
@@ -1196,9 +1196,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             var style1Z = parseInt(window.getComputedStyle(overlay1).zIndex, 10);
             var style2Z = parseInt(window.getComputedStyle(overlay2).zIndex, 10);
             var bgStyleZ = parseInt(window.getComputedStyle(overlay1.backdropElement).zIndex, 10);
-            assert.isAbove(style2Z, style1Z, 'overlay1 above overlay2');
-            assert.isAbove(style2Z, bgStyleZ, 'backdrop above overlay2');
-            assert.isBelow(style1Z, bgStyleZ, 'backdrop below overlay1');
+            assert.isAbove(style2Z, style1Z, 'overlay2 above overlay1');
+            assert.isAbove(style2Z, bgStyleZ, 'overlay2 above backdrop');
+            assert.isBelow(style1Z, bgStyleZ, 'overlay1 below backdrop');
             done();
           });
         });
@@ -1211,8 +1211,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             var style1Z = parseInt(window.getComputedStyle(overlay1).zIndex, 10);
             var style2Z = parseInt(window.getComputedStyle(overlay2).zIndex, 10);
             var bgStyleZ = parseInt(window.getComputedStyle(overlay1.backdropElement).zIndex, 10);
-            assert.isAbove(style2Z, bgStyleZ, 'backdrop above overlay2');
-            assert.isAbove(style1Z, bgStyleZ, 'backdrop below overlay1');
+            assert.isAbove(style2Z, bgStyleZ, 'overlay2 above backdrop');
+            assert.isAbove(style1Z, bgStyleZ, 'overlay1 below backdrop');
             done();
           });
         });

--- a/test/iron-overlay-behavior.html
+++ b/test/iron-overlay-behavior.html
@@ -1193,11 +1193,26 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       test('newest overlay appear on top', function(done) {
         runAfterOpen(overlay1, function() {
           runAfterOpen(overlay2, function() {
-            var styleZ = parseInt(window.getComputedStyle(overlay1).zIndex, 10);
-            var style1Z = parseInt(window.getComputedStyle(overlay2).zIndex, 10);
+            var style1Z = parseInt(window.getComputedStyle(overlay1).zIndex, 10);
+            var style2Z = parseInt(window.getComputedStyle(overlay2).zIndex, 10);
             var bgStyleZ = parseInt(window.getComputedStyle(overlay1.backdropElement).zIndex, 10);
-            assert.isTrue(style1Z > styleZ, 'overlay2 has higher z-index than overlay1');
-            assert.isTrue(styleZ > bgStyleZ, 'overlay1 has higher z-index than backdrop');
+            assert.isAbove(style2Z, style1Z, 'overlay1 above overlay2');
+            assert.isAbove(style2Z, bgStyleZ, 'backdrop above overlay2');
+            assert.isBelow(style1Z, bgStyleZ, 'backdrop below overlay1');
+            done();
+          });
+        });
+      });
+
+      test('updating with-backdrop updates z-index', function(done) {
+        runAfterOpen(overlay1, function() {
+          runAfterOpen(overlay2, function() {
+            overlay2.withBackdrop = false;
+            var style1Z = parseInt(window.getComputedStyle(overlay1).zIndex, 10);
+            var style2Z = parseInt(window.getComputedStyle(overlay2).zIndex, 10);
+            var bgStyleZ = parseInt(window.getComputedStyle(overlay1.backdropElement).zIndex, 10);
+            assert.isAbove(style2Z, bgStyleZ, 'backdrop above overlay2');
+            assert.isAbove(style1Z, bgStyleZ, 'backdrop below overlay1');
             done();
           });
         });
@@ -1231,20 +1246,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
               assert.isTrue(overlay1.opened, 'overlay1 still opened');
               done();
             });
-          });
-        });
-      });
-
-      test('updating with-backdrop updates z-index', function(done) {
-        runAfterOpen(overlay1, function() {
-          runAfterOpen(overlay2, function() {
-            overlay1.withBackdrop = false;
-            var styleZ = parseInt(window.getComputedStyle(overlay1).zIndex, 10);
-            var style1Z = parseInt(window.getComputedStyle(overlay2).zIndex, 10);
-            var bgStyleZ = parseInt(window.getComputedStyle(overlay1.backdropElement).zIndex, 10);
-            assert.isTrue(style1Z > bgStyleZ, 'overlay2 has higher z-index than backdrop');
-            assert.isTrue(styleZ < bgStyleZ, 'overlay1 has lower z-index than backdrop');
-            done();
           });
         });
       });


### PR DESCRIPTION
Fixes #124.
Given 2 overlays with backdrop, the last one to be opened should have the backdrop below it, meaning the backdrop should be rendered between the 2 overlays.