### PR TITLE
Capture scroll events

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -285,6 +285,36 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       </simple-overlay>
     </template>
   </demo-snippet>
+  
+  <h3>Use <code>scroll-action</code> to lock, refit or cancel an overlay on scroll.</h3>
+  <demo-snippet>
+    <template>
+      <span>
+        <button onclick="lockOnScroll.open()">locks scroll</button>
+        <simple-overlay id="lockOnScroll" scroll-action="lock" no-overlap
+                        vertical-align="bottom" horizontal-align="left" tabindex=-1>
+          <h2>Prevents scroll outside</h2>
+          <button onclick="lockOnScroll.close()">Close this</button>
+        </simple-overlay>
+      </span>
+      <span>
+        <button onclick="refitOnScroll.open()">refits on scroll</button>
+        <simple-overlay id="refitOnScroll" scroll-action="refit" no-overlap
+                        vertical-align="bottom" horizontal-align="left" tabindex=-1>
+          <h2>Refits on scroll</h2>
+          <button onclick="refitOnScroll.close()">Close this</button>
+        </simple-overlay>
+      </span>
+      <span>
+        <button onclick="cancelOnScroll.open()">cancels on scroll</button>
+        <simple-overlay id="cancelOnScroll" scroll-action="cancel" no-overlap
+                        vertical-align="bottom" horizontal-align="left" tabindex=-1>
+          <h2>Cancels on scroll</h2>
+          <button onclick="cancelOnScroll.close()">Close this</button>
+        </simple-overlay>
+      </span>
+    </template>
+  </demo-snippet>
 
 </body>
 

--- a/iron-overlay-behavior.html
+++ b/iron-overlay-behavior.html
@@ -643,13 +643,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     __addScrollListeners: function() {
       if (!this.__rootNodes) {
         this.__rootNodes = [];
-        // If we are hosted in shadowRoots, listen for scroll
-        // events in there too.
-        if ('getRootNode' in Element.prototype) {
-          var rootNode = this.getRootNode();
-          while (rootNode && rootNode.host) {
-            this.__rootNodes.push(rootNode);
-            rootNode = rootNode.host.getRootNode();
+        // Listen for scroll events in all shadowRoots hosting this overlay.
+        var node = this;
+        while (node) {
+          if (node.nodeType === Node.DOCUMENT_FRAGMENT_NODE) {
+            if (node.host) {
+              this.__rootNodes.push(node);
+            }
+            node = node.host;
+          } else {
+            node = node.assignedSlot || node.parentNode;
           }
         }
         this.__rootNodes.push(document);

--- a/iron-overlay-behavior.html
+++ b/iron-overlay-behavior.html
@@ -197,6 +197,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       // Scroll info to be restored.
       this.__scrollTop = this.__scrollLeft = null;
       this.__onCaptureScroll = this.__onCaptureScroll.bind(this);
+      // Root nodes hosting the overlay, used to listen for scroll events on them.
+      this.__rootNodes = null;
       this._ensureSetup();
     },
 
@@ -625,17 +627,55 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     __updateScrollObservers: function(isAttached, opened, scrollAction) {
       if (!isAttached || !opened || !this.__isValidScrollAction(scrollAction)) {
         Polymer.IronScrollManager.removeScrollLock(this);
-        document.removeEventListener('scroll', this.__onCaptureScroll, {
-          passive: true
-        });
+        this.__removeScrollListeners();
       } else {
         if (scrollAction === 'lock') {
           this.__saveScrollPosition();
           Polymer.IronScrollManager.pushScrollLock(this);
         }
-        document.addEventListener('scroll', this.__onCaptureScroll, {
-          passive: true
+        this.__addScrollListeners();
+      }
+    },
+    
+    /**
+     * @private
+     */
+    __addScrollListeners: function() {
+      if (!this.__rootNodes) {
+        this.__rootNodes = [];
+        // If we are hosted in shadowRoots, listen for scroll
+        // events in there too.
+        if ('getRootNode' in Element.prototype) {
+          var rootNode = this.getRootNode();
+          while (rootNode && rootNode.host) {
+            this.__rootNodes.push(rootNode);
+            rootNode = rootNode.host.getRootNode();
+          }
+        }
+        this.__rootNodes.push(document);
+      }
+      this.__rootNodes.forEach(function(el) {
+        el.addEventListener('scroll', this.__onCaptureScroll, {
+          capture: true,
+          passive: true,
         });
+      }, this);
+    },
+    
+    /**
+     * @private
+     */
+    __removeScrollListeners: function() {
+      if (this.__rootNodes) {
+        this.__rootNodes.forEach(function(el) {
+          el.removeEventListener('scroll', this.__onCaptureScroll, {
+            capture: true,
+            passive: true,
+          });
+        }, this);
+      }
+      if (!this.isAttached) {
+        this.__rootNodes = null;
       }
     },
 
@@ -655,6 +695,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      */
     __onCaptureScroll: function(event) {
       if (this.__isAnimating) {
+        return;
+      }
+      // Check if scroll outside the overlay.
+      if (Polymer.dom(event).path.indexOf(this) >= 0) {
         return;
       }
       switch (this.scrollAction) {

--- a/iron-overlay-behavior.html
+++ b/iron-overlay-behavior.html
@@ -643,16 +643,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     __addScrollListeners: function() {
       if (!this.__rootNodes) {
         this.__rootNodes = [];
-        // Listen for scroll events in all shadowRoots hosting this overlay.
-        var node = this;
-        while (node) {
-          if (node.nodeType === Node.DOCUMENT_FRAGMENT_NODE) {
-            if (node.host) {
+        // Listen for scroll events in all shadowRoots hosting this overlay only
+        // when in native ShadowDOM.
+        if ('attachShadow' in Element.prototype && 'getRootNode' in Element.prototype) {
+          var node = this;
+          while (node) {
+            if (node.nodeType === Node.DOCUMENT_FRAGMENT_NODE && node.host) {
               this.__rootNodes.push(node);
             }
-            node = node.host;
-          } else {
-            node = node.assignedSlot || node.parentNode;
+            node = node.host || node.assignedSlot || node.parentNode;
           }
         }
         this.__rootNodes.push(document);

--- a/test/iron-overlay-behavior-scroll-actions.html
+++ b/test/iron-overlay-behavior-scroll-actions.html
@@ -60,6 +60,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       <test-scrollable>
         <div slot="scrollable-content" class="big">
           This element makes the overlay scrollable.
+          <test-overlay>Overlay in light dom</test-overlay>
         </div>
         <div slot="overlay-content" class="big">Overlay in shadow root</div>
       </test-scrollable>
@@ -229,13 +230,75 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     });
 
-    suite('scroll actions in ShadowDOM', function() {
+    suite('scroll actions in shadow root', function() {
 
       var scrollable, overlay;
       setup(function() {
         var f = fixture('scrollable');
         scrollable = f.$.scrollable;
         overlay = f.$.overlay;
+      });
+
+      test('refit scrollAction does NOT refit the overlay on scroll inside', function(done) {
+        overlay.scrollAction = 'refit';
+        runAfterOpen(overlay, function() {
+          var refitSpy = sinon.spy(overlay, 'refit');
+          dispatchScroll(overlay, 0, 10);
+          Polymer.RenderStatus.afterNextRender(overlay, function() {
+            assert.equal(refitSpy.callCount, 0, 'did not refit on scroll inside');
+            done();
+          });
+        });
+      });
+
+      test('refit scrollAction refits the overlay on scroll outside', function(done) {
+        overlay.scrollAction = 'refit';
+        runAfterOpen(overlay, function() {
+          var refitSpy = sinon.spy(overlay, 'refit');
+          dispatchScroll(scrollable, 0, 10);
+          Polymer.RenderStatus.afterNextRender(overlay, function() {
+            assert.notEqual(refitSpy.callCount, 0, 'did refit on scroll outside');
+            done();
+          });
+        });
+      });
+
+      test('cancel scrollAction does NOT close the overlay on scroll inside', function(done) {
+        overlay.scrollAction = 'cancel';
+        runAfterOpen(overlay, function() {
+          dispatchScroll(overlay, 0, 10);
+          assert.isTrue(overlay.opened, 'overlay was not closed');
+          done();
+        });
+      });
+
+      test('cancel scrollAction closes the overlay on scroll outside', function(done) {
+        overlay.scrollAction = 'cancel';
+        runAfterOpen(overlay, function() {
+          overlay.addEventListener('iron-overlay-canceled', function(event) {
+            assert.equal(event.detail.type, 'scroll', 'detail contains original event');
+            // In Polymer 1.x with dom=shadow, triggering a scroll event on a node inside a shadowRoot
+            // doesn't set the correct target, so we skip this check. 
+            if (Polymer.Element || !Polymer.Settings.useShadow) {
+              assert.equal(event.detail.target, scrollable, 'original scroll event target ok');
+            }
+            overlay.addEventListener('iron-overlay-closed', function() {
+              done();
+            });
+          });
+          dispatchScroll(scrollable, 0, 10);
+        });
+      });
+
+    });
+
+    suite('scroll actions in shadow root, overlay distributed', function() {
+
+      var scrollable, overlay;
+      setup(function() {
+        var f = fixture('scrollable');
+        scrollable = f.$.scrollable;
+        overlay = Polymer.dom(f).querySelector('test-overlay');
       });
 
       test('refit scrollAction does NOT refit the overlay on scroll inside', function(done) {

--- a/test/iron-overlay-behavior-scroll-actions.html
+++ b/test/iron-overlay-behavior-scroll-actions.html
@@ -146,11 +146,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       test('refit scrollAction does NOT refit the overlay on scroll inside', function(done) {
         overlay.scrollAction = 'refit';
         runAfterOpen(overlay, function() {
-          var refitSpy = sinon.spy(overlay, 'refit');
-          dispatchScroll(overlay, 0, 10);
-          Polymer.RenderStatus.afterNextRender(overlay, function() {
-            assert.equal(refitSpy.callCount, 0, 'did not refit on scroll inside');
-            done();
+          // Wait a tick, otherwise this fails in FF/Safari.
+          setTimeout(function() {
+            var refitSpy = sinon.spy(overlay, 'refit');
+            dispatchScroll(overlay, 0, 10);
+            Polymer.RenderStatus.afterNextRender(overlay, function() {
+              assert.equal(refitSpy.callCount, 0, 'did not refit on scroll inside');
+              done();
+            });
           });
         });
       });
@@ -182,9 +185,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           overlay.addEventListener('iron-overlay-canceled', function(event) {
             assert.equal(event.detail.type, 'scroll', 'detail contains original event');
             assert.equal(event.detail.target, scrollTarget, 'original scroll event target ok');
-          });
-          overlay.addEventListener('iron-overlay-closed', function() {
-            done();
+            overlay.addEventListener('iron-overlay-closed', function() {
+              done();
+            });
           });
           dispatchScroll(scrollTarget, 0, 10);
         });
@@ -273,10 +276,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         runAfterOpen(overlay, function() {
           overlay.addEventListener('iron-overlay-canceled', function(event) {
             assert.equal(event.detail.type, 'scroll', 'detail contains original event');
-            assert.equal(event.detail.target, scrollable, 'original scroll event target ok');
-          });
-          overlay.addEventListener('iron-overlay-closed', function() {
-            done();
+            // In Polymer 1.x with dom=shadow, triggering a scroll event on a node inside a shadowRoot
+            // doesn't set the correct target, so we skip this check. 
+            if (Polymer.Element || !Polymer.Settings.useShadow) {
+              assert.equal(event.detail.target, scrollable, 'original scroll event target ok');
+            }
+            overlay.addEventListener('iron-overlay-closed', function() {
+              done();
+            });
           });
           dispatchScroll(scrollable, 0, 10);
         });

--- a/test/iron-overlay-behavior-scroll-actions.html
+++ b/test/iron-overlay-behavior-scroll-actions.html
@@ -22,20 +22,47 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <script src="../../web-component-tester/browser.js"></script>
   <link rel="import" href="test-overlay.html">
+  <link rel="import" href="test-scrollable.html">
 
 </head>
 
 <body>
 
-  <div style="width: 150vmax; height: 150vmax">
+  <style>
+    .scrollable {
+      overflow: auto;
+      width: 200px;
+      height: 200px;
+    }
+
+    .big {
+      width: 150vmax;
+      height: 150vmax;
+    }
+  </style>
+
+  <div class="big">
     This element makes the page scrollable.
   </div>
 
   <test-fixture id="basic">
     <template>
-      <test-overlay>
-        Basic Overlay
+      <test-overlay class="scrollable">
+        <div class="big">
+          This element makes the overlay scrollable.
+        </div>
       </test-overlay>
+    </template>
+  </test-fixture>
+
+  <test-fixture id="scrollable">
+    <template>
+      <test-scrollable>
+        <div slot="scrollable-content" class="big">
+          This element makes the overlay scrollable.
+        </div>
+        <div slot="overlay-content" class="big">Overlay in shadow root</div>
+      </test-scrollable>
     </template>
   </test-fixture>
 
@@ -79,7 +106,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       target.scrollTop = scrollTop;
       target.dispatchEvent(new CustomEvent('scroll', {
         bubbles: true,
-        composed: true
+        composed: false
       }));
     }
 
@@ -116,19 +143,40 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
       });
 
-      test('refit scrollAction refits the overlay', function(done) {
+      test('refit scrollAction does NOT refit the overlay on scroll inside', function(done) {
         overlay.scrollAction = 'refit';
         runAfterOpen(overlay, function() {
           var refitSpy = sinon.spy(overlay, 'refit');
-          dispatchScroll(scrollTarget, 0, 10);
+          dispatchScroll(overlay, 0, 10);
           Polymer.RenderStatus.afterNextRender(overlay, function() {
-            assert.notEqual(refitSpy.callCount, 0, 'did refit on scroll');
+            assert.equal(refitSpy.callCount, 0, 'did not refit on scroll inside');
             done();
           });
         });
       });
 
-      test('cancel scrollAction cancels/closes the overlay on scroll', function(done) {
+      test('refit scrollAction refits the overlay on scroll outside', function(done) {
+        overlay.scrollAction = 'refit';
+        runAfterOpen(overlay, function() {
+          var refitSpy = sinon.spy(overlay, 'refit');
+          dispatchScroll(scrollTarget, 0, 10);
+          Polymer.RenderStatus.afterNextRender(overlay, function() {
+            assert.notEqual(refitSpy.callCount, 0, 'did refit on scroll outside');
+            done();
+          });
+        });
+      });
+
+      test('cancel scrollAction does NOT close the overlay on scroll inside', function(done) {
+        overlay.scrollAction = 'cancel';
+        runAfterOpen(overlay, function() {
+          dispatchScroll(overlay, 0, 10);
+          assert.isTrue(overlay.opened, 'overlay was not closed');
+          done();
+        });
+      });
+
+      test('cancel scrollAction closes the overlay on scroll outside', function(done) {
         overlay.scrollAction = 'cancel';
         runAfterOpen(overlay, function() {
           overlay.addEventListener('iron-overlay-canceled', function(event) {
@@ -173,6 +221,64 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             done();
           }
           openCount++;
+        });
+      });
+
+    });
+
+    suite('scroll actions in ShadowDOM', function() {
+
+      var scrollable, overlay;
+      setup(function() {
+        var f = fixture('scrollable');
+        scrollable = f.$.scrollable;
+        overlay = f.$.overlay;
+      });
+
+      test('refit scrollAction does NOT refit the overlay on scroll inside', function(done) {
+        overlay.scrollAction = 'refit';
+        runAfterOpen(overlay, function() {
+          var refitSpy = sinon.spy(overlay, 'refit');
+          dispatchScroll(overlay, 0, 10);
+          Polymer.RenderStatus.afterNextRender(overlay, function() {
+            assert.equal(refitSpy.callCount, 0, 'did not refit on scroll inside');
+            done();
+          });
+        });
+      });
+
+      test('refit scrollAction refits the overlay on scroll outside', function(done) {
+        overlay.scrollAction = 'refit';
+        runAfterOpen(overlay, function() {
+          var refitSpy = sinon.spy(overlay, 'refit');
+          dispatchScroll(scrollable, 0, 10);
+          Polymer.RenderStatus.afterNextRender(overlay, function() {
+            assert.notEqual(refitSpy.callCount, 0, 'did refit on scroll outside');
+            done();
+          });
+        });
+      });
+
+      test('cancel scrollAction does NOT close the overlay on scroll inside', function(done) {
+        overlay.scrollAction = 'cancel';
+        runAfterOpen(overlay, function() {
+          dispatchScroll(overlay, 0, 10);
+          assert.isTrue(overlay.opened, 'overlay was not closed');
+          done();
+        });
+      });
+
+      test('cancel scrollAction closes the overlay on scroll outside', function(done) {
+        overlay.scrollAction = 'cancel';
+        runAfterOpen(overlay, function() {
+          overlay.addEventListener('iron-overlay-canceled', function(event) {
+            assert.equal(event.detail.type, 'scroll', 'detail contains original event');
+            assert.equal(event.detail.target, scrollable, 'original scroll event target ok');
+          });
+          overlay.addEventListener('iron-overlay-closed', function() {
+            done();
+          });
+          dispatchScroll(scrollable, 0, 10);
         });
       });
 

--- a/test/test-scrollable.html
+++ b/test/test-scrollable.html
@@ -1,0 +1,42 @@
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+
+<link rel="import" href="../../polymer/polymer.html">
+
+<link rel="import" href="./test-overlay.html">
+
+<dom-module id="test-scrollable">
+  <template>
+    <style>
+      #scrollable, #overlay {
+        max-width: 200px;
+        max-height: 200px;
+        overflow: auto;
+      }
+    </style>
+    <div id="scrollable">
+      <slot name="scrollable-content"></slot>
+    </div>
+    <test-overlay id="overlay">
+      <slot name="overlay-content"></slot>
+    </test-overlay>
+  </template>
+
+</dom-module>
+
+<script>
+  (function() {
+
+    Polymer({
+      is: 'test-scrollable'
+    });
+
+  })();
+</script>


### PR DESCRIPTION
Fixes #254.
Listen for `scroll` events in all shadowRoots hosting the overlay, up to the main `document`.

Note that:
- if the scroll happens inside a shadowRoot that is not in the overlay's path, it won't be captured
- this doesn't guarantee preventing scrolls happening in any node different from `document`

e.g. see http://jsbin.com/wewemu/6/edit?html - scroll events happening in `scrollable_0` cannot be handled by the opened overlays, as they are contained in `scrollable_1`. For these cases, the user is expected to listen to the scroll events on different targets, and then calling `refit` or `cancel` on the overlay.