### PR TITLE
Fix __addScrollListeners for polyfilled browsers

### DIFF
--- a/iron-overlay-behavior.d.ts
+++ b/iron-overlay-behavior.d.ts
@@ -64,7 +64,7 @@ declare namespace Polymer {
     restoreFocusOnClose: boolean|null|undefined;
 
     /**
-     * Set to true to allow clicks to go through overlays. 
+     * Set to true to allow clicks to go through overlays.
      * When the user clicks outside this overlay, the click may
      * close the overlay below.
      */

--- a/iron-overlay-behavior.html
+++ b/iron-overlay-behavior.html
@@ -98,7 +98,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       },
 
       /**
-       * Set to true to allow clicks to go through overlays. 
+       * Set to true to allow clicks to go through overlays.
        * When the user clicks outside this overlay, the click may
        * close the overlay below.
        */
@@ -636,7 +636,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         this.__addScrollListeners();
       }
     },
-    
+
     /**
      * @private
      */
@@ -645,7 +645,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         this.__rootNodes = [];
         // Listen for scroll events in all shadowRoots hosting this overlay only
         // when in native ShadowDOM.
-        if ('attachShadow' in Element.prototype && 'getRootNode' in Element.prototype) {
+        if (Polymer.Settings.useShadow) {
           var node = this;
           while (node) {
             if (node.nodeType === Node.DOCUMENT_FRAGMENT_NODE && node.host) {
@@ -663,7 +663,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
       }, this);
     },
-    
+
     /**
      * @private
      */

--- a/test/iron-overlay-behavior-scroll-actions.html
+++ b/test/iron-overlay-behavior-scroll-actions.html
@@ -232,6 +232,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     suite('scroll actions in shadow root', function() {
 
+      suiteSetup(function() {
+        if (!Polymer.Settings.useShadow) {
+          this.skip();
+        }
+      });
+
       var scrollable, overlay;
       setup(function() {
         var f = fixture('scrollable');
@@ -278,7 +284,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           overlay.addEventListener('iron-overlay-canceled', function(event) {
             assert.equal(event.detail.type, 'scroll', 'detail contains original event');
             // In Polymer 1.x with dom=shadow, triggering a scroll event on a node inside a shadowRoot
-            // doesn't set the correct target, so we skip this check. 
+            // doesn't set the correct target, so we skip this check.
             if (Polymer.Element || !Polymer.Settings.useShadow) {
               assert.equal(event.detail.target, scrollable, 'original scroll event target ok');
             }
@@ -293,6 +299,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     });
 
     suite('scroll actions in shadow root, overlay distributed', function() {
+
+      suiteSetup(function() {
+        if (!Polymer.Settings.useShadow) {
+          this.skip();
+        }
+      });
 
       var scrollable, overlay;
       setup(function() {
@@ -340,7 +352,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           overlay.addEventListener('iron-overlay-canceled', function(event) {
             assert.equal(event.detail.type, 'scroll', 'detail contains original event');
             // In Polymer 1.x with dom=shadow, triggering a scroll event on a node inside a shadowRoot
-            // doesn't set the correct target, so we skip this check. 
+            // doesn't set the correct target, so we skip this check.
             if (Polymer.Element || !Polymer.Settings.useShadow) {
               assert.equal(event.detail.target, scrollable, 'original scroll event target ok');
             }
@@ -351,7 +363,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           dispatchScroll(scrollable, 0, 10);
         });
       });
-
     });
   </script>
 


### PR DESCRIPTION
The comment above the line I changed says:

> Listen for scroll events in all shadowRoots hosting this overlay only when in **native ShadowDOM**

It's not possible to detect the native ShadowDOM by checking only `'attachShadow' in Element.prototype && 'getRootNode' in Element.prototype`:

Firefox | IE11
---|---
![](https://i.imgur.com/zicWrxa.png) | ![](https://i.imgur.com/VEMqkBS.png)