### PR TITLE
Fix #269: TypeError: observerHandle is null in Firefox

### DIFF
--- a/iron-overlay-behavior.html
+++ b/iron-overlay-behavior.html
@@ -214,7 +214,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     },
 
     detached: function() {
-      Polymer.dom(this).unobserveNodes(this._observer);
+      if (this._observer) {
+        Polymer.dom(this).unobserveNodes(this._observer);
+      }
       this._observer = null;
       for (var cb in this.__rafs) {
         if (this.__rafs[cb] !== null) {


### PR DESCRIPTION
This fixes the linked issue, but I'm not 100% sure it won't break anything under the hood.