### PR TITLE
Prevent open again when click on the trigger!

### DIFF
--- a/iron-overlay-behavior.html
+++ b/iron-overlay-behavior.html
@@ -462,9 +462,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      * @protected
      */
     _onCaptureClick: function(event) {
-      if (!this.noCancelOnOutsideClick) {
-        this.cancel(event);
-      }
+      // use async to make delay for prevent open again when click on dropdown-trigger!
+      this.async(() => { 
+        if (!this.noCancelOnOutsideClick) {
+          this.cancel(event);
+        }
+      });
     },
 
     /**


### PR DESCRIPTION
In `iron-dropdown` element when user click on the trigger when the dropdown is open, dropdown close and after that it open again and use see a flash on dropdown-content

To prevent this we need to call `cancel` asynchronous to make a delay.

Before this PR I simply try to `if (this.opened) return;` in my trigger function but dropdown closed before trigger event then I forced to make this PR!