### PR TITLE
Declare _boundScrollHandler so that modulizer sees it

### DIFF
--- a/iron-scroll-manager.html
+++ b/iron-scroll-manager.html
@@ -219,6 +219,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         }
       },
 
+      /**
+       * @private
+       */
+      _boundScrollHandler: undefined,
+      
       _lockScrollInteractions: function() {
         this._boundScrollHandler = this._boundScrollHandler ||
           this._scrollInteractionHandler.bind(this);


### PR DESCRIPTION
Without, we get an undeclared variable here: https://github.com/PolymerElements/iron-overlay-behavior/blob/__auto_generated_3.0_preview/iron-scroll-manager.js#L163