### PR TITLE
no need to _applyFocus on new currentOverlay

### DIFF
--- a/iron-overlay-behavior.html
+++ b/iron-overlay-behavior.html
@@ -430,8 +430,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         }
       }
       else {
-        this._focusNode.blur();
-        this._focusedChild = null;
         // Restore focus.
         if (this.restoreFocusOnClose && this.__restoreFocusNode) {
           // If the activeElement is `<body>` or inside the overlay,
@@ -446,13 +444,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           }
         }
         this.__restoreFocusNode = null;
-        // If many overlays get closed at the same time, one of them would still
-        // be the currentOverlay even if already closed, and would call _applyFocus
-        // infinitely, so we check for this not to be the current overlay.
-        var currentOverlay = this._manager.currentOverlay();
-        if (currentOverlay && this !== currentOverlay) {
-          currentOverlay._applyFocus();
-        }
+        this._focusNode.blur();
+        this._focusedChild = null;
       }
     },
 


### PR DESCRIPTION
Fixes https://github.com/PolymerElements/paper-toast/issues/97.
Here the repro showing the fix - click on the input and notice the focus never leaves it http://output.jsbin.com/tuleyag/2/quiet

We don't need to invoke `_applyFocus` to the new overlay because restoring of the focus is already handled by 2 other code blocks: 
- `restoreFocusOnClose` logic already handles restoring the focus if the user didn't move it to another element (e.g. click on another button)
- `_onCaptureFocus` logic takes care of bringing back the focus to the overlay when needed.

Focus handling tests already cover most of these interactions, and adding a new test for this case would result in testing an implementation detail (e.g. "test that _applyFocus is not called").