### PR TITLE
Fix modulizer

### DIFF
--- a/iron-overlay-backdrop.html
+++ b/iron-overlay-backdrop.html
@@ -69,12 +69,14 @@ Custom property | Description | Default
         reflectToAttribute: true,
         type: Boolean,
         value: false,
-        observer: '_openedChanged'
+        observer: '_openedChanged',
       }
 
     },
 
-    listeners: {'transitionend': '_onTransitionend'},
+    listeners: {
+      'transitionend': '_onTransitionend',
+    },
 
     created: function() {
       // Used to cancel previous requestAnimationFrame calls when opened changes.

--- a/iron-overlay-behavior.html
+++ b/iron-overlay-behavior.html
@@ -44,23 +44,35 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * Set to true to display a backdrop behind the overlay. It traps the focus
        * within the light DOM of the overlay.
        */
-      withBackdrop: {observer: '_withBackdropChanged', type: Boolean},
+      withBackdrop: {
+        observer: '_withBackdropChanged',
+        type: Boolean,
+      },
 
       /**
        * Set to true to disable auto-focusing the overlay or child nodes with
        * the `autofocus` attribute` when the overlay is opened.
        */
-      noAutoFocus: {type: Boolean, value: false},
+      noAutoFocus: {
+        type: Boolean,
+        value: false,
+      },
 
       /**
        * Set to true to disable canceling the overlay with the ESC key.
        */
-      noCancelOnEscKey: {type: Boolean, value: false},
+      noCancelOnEscKey: {
+        type: Boolean,
+        value: false,
+      },
 
       /**
        * Set to true to disable canceling the overlay by clicking outside it.
        */
-      noCancelOnOutsideClick: {type: Boolean, value: false},
+      noCancelOnOutsideClick: {
+        type: Boolean,
+        value: false,
+      },
 
       /**
        * Contains the reason(s) this overlay was last closed (see
@@ -71,25 +83,32 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       closingReason: {
         // was a getter before, but needs to be a property so other
         // behaviors can override this.
-        type: Object
+        type: Object,
       },
 
       /**
        * Set to true to enable restoring of focus when overlay is closed.
        */
-      restoreFocusOnClose: {type: Boolean, value: false},
+      restoreFocusOnClose: {
+        type: Boolean,
+        value: false,
+      },
 
       /**
        * Set to true to allow clicks to go through overlays.
        * When the user clicks outside this overlay, the click may
        * close the overlay below.
        */
-      allowClickThrough: {type: Boolean},
+      allowClickThrough: {
+        type: Boolean,
+      },
 
       /**
        * Set to true to keep overlay always on top.
        */
-      alwaysOnTop: {type: Boolean},
+      alwaysOnTop: {
+        type: Boolean,
+      },
 
       /**
        * Determines which action to perform when scroll outside an opened overlay
@@ -97,20 +116,27 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * computes the new position on the overlay cancel - causes the overlay to
        * close
        */
-      scrollAction: {type: String},
+      scrollAction: {
+        type: String,
+      },
 
       /**
        * Shortcut to access to the overlay manager.
        * @private
        * @type {!Polymer.IronOverlayManagerClass}
        */
-      _manager: {type: Object, value: Polymer.IronOverlayManager},
+      _manager: {
+        type: Object,
+        value: Polymer.IronOverlayManager,
+      },
 
       /**
        * The node being focused.
        * @type {?Node}
        */
-      _focusedChild: {type: Object}
+      _focusedChild: {
+        type: Object,
+      }
 
     },
 

--- a/iron-scroll-manager.html
+++ b/iron-scroll-manager.html
@@ -43,6 +43,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   ];
   // must be defined for modulizer
   var _boundScrollHandler;
+  if (!window.Polymer) {
+    window.Polymer = {};
+  }
 
   /**
    * The IronScrollManager is intended to provide a central source

--- a/iron-scroll-manager.html
+++ b/iron-scroll-manager.html
@@ -101,8 +101,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         return false;
       }
 
-      scrollLocked = !!lockingElement &&
-          lockingElement !== element &&
+      scrollLocked = !!lockingElement && lockingElement !== element &&
           !this._composedTreeContains(lockingElement, element);
 
       if (scrollLocked) {
@@ -240,8 +239,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     _lockScrollInteractions: function() {
       try {
-        this._boundScrollHandler =
-            this._boundScrollHandler || this._scrollInteractionHandler.bind(scope);
+        this._boundScrollHandler = this._boundScrollHandler ||
+            this._scrollInteractionHandler.bind(scope);
       } catch (e) {
         this._boundScrollHandler =
             this._boundScrollHandler || this._scrollInteractionHandler;

--- a/iron-scroll-manager.html
+++ b/iron-scroll-manager.html
@@ -228,14 +228,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     _boundScrollHandler: undefined,
 
     _lockScrollInteractions: function() {
-      // workaround for modulizer not handling bind properly
-      if (!this._boundScrollHandler) {
-        try {
-          this._boundScrollHandler = this._scrollInteractionHandler.bind(this);
-        } catch (e) {
-          this._boundScrollHandler = this._scrollInteractionHandler;
-        }
-      }
+      this._boundScrollHandler =
+          this._boundScrollHandler || this._scrollInteractionHandler.bind(this);
       for (var i = 0, l = scrollEvents.length; i < l; i++) {
         // NOTE: browsers that don't support objects as third arg will
         // interpret it as boolean, hence useCapture = true in this case.

--- a/iron-scroll-manager.html
+++ b/iron-scroll-manager.html
@@ -41,6 +41,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     'touchstart',
     'touchmove'
   ];
+  // must be defined for modulizer
+  var _boundScrollHandler;
 
   /**
    * The IronScrollManager is intended to provide a central source

--- a/iron-scroll-manager.html
+++ b/iron-scroll-manager.html
@@ -43,6 +43,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   ];
   // must be defined for modulizer
   var _boundScrollHandler;
+  var scope;
 
   /**
    * The IronScrollManager is intended to provide a central source
@@ -52,7 +53,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
    * @namespace
    * @memberof Polymer
    */
-  IronScrollManager = {
+  Polymer.IronScrollManager = {
 
     /**
      * The current element that defines the DOM boundaries of the
@@ -218,17 +219,19 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       return false;
     },
 
-    _scrollInteractionHandler: function(event) {
-      // Avoid canceling an event with cancelable=false, e.g. scrolling is in
-      // progress and cannot be interrupted.
-      if (event.cancelable && this._shouldPreventScrolling(event)) {
-        event.preventDefault();
-      }
-      // If event has targetTouches (touch event), update last touch position.
-      if (event.targetTouches) {
-        var touch = event.targetTouches[0];
-        lastTouchPosition.pageX = touch.pageX;
-        lastTouchPosition.pageY = touch.pageY;
+    getScrollHandler: function(shouldPreventScrolling) {
+      return function(event) {
+        // Avoid canceling an event with cancelable=false, e.g. scrolling is in
+        // progress and cannot be interrupted.
+        if (event.cancelable && shouldPreventScrolling(event)) {
+          event.preventDefault();
+        }
+        // If event has targetTouches (touch event), update last touch position.
+        if (event.targetTouches) {
+          var touch = event.targetTouches[0];
+          lastTouchPosition.pageX = touch.pageX;
+          lastTouchPosition.pageY = touch.pageY;
+        }
       }
     },
 
@@ -239,7 +242,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     _lockScrollInteractions: function() {
       this._boundScrollHandler =
-          this._boundScrollHandler || this._scrollInteractionHandler.bind(this);
+          this._boundScrollHandler || this.getScrollHandler(this._shouldPreventScrolling);
       for (var i = 0, l = scrollEvents.length; i < l; i++) {
         // NOTE: browsers that don't support objects as third arg will
         // interpret it as boolean, hence useCapture = true in this case.
@@ -402,6 +405,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     }
   };
 
-  Polymer.IronScrollManager = IronScrollManager;
+  scope = Polymer.IronScrollManager;
   })();
 </script>

--- a/iron-scroll-manager.html
+++ b/iron-scroll-manager.html
@@ -43,9 +43,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   ];
   // must be defined for modulizer
   var _boundScrollHandler;
-  if (!Polymer) {
-    Polymer = {};
-  };
 
   /**
    * The IronScrollManager is intended to provide a central source
@@ -55,8 +52,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
    * @namespace
    * @memberof Polymer
    */
-  Polymer['IronScrollManager'] = {
-      /**
+  IronScrollManager = {
+
+    /**
      * The current element that defines the DOM boundaries of the
      * scroll lock. This is always the most recently locking element.
      *
@@ -403,5 +401,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       return info;
     }
   };
+
+  Polymer.IronScrollManager = IronScrollManager;
   })();
 </script>

--- a/iron-scroll-manager.html
+++ b/iron-scroll-manager.html
@@ -121,7 +121,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
 
       this._lockingElements.push(element);
-      this.currentLockingElement = this._lockingElements[this._lockingElements.length - 1];
+      this.currentLockingElement =
+          this._lockingElements[this._lockingElements.length - 1];
 
       this._lockedElementCache = [];
       this._unlockedElementCache = [];
@@ -145,7 +146,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
 
       this._lockingElements.splice(index, 1);
-      this.currentLockingElement = this._lockingElements[this._lockingElements.length - 1];
+      this.currentLockingElement =
+          this._lockingElements[this._lockingElements.length - 1];
 
       this._lockedElementCache = [];
       this._unlockedElementCache = [];

--- a/iron-scroll-manager.html
+++ b/iron-scroll-manager.html
@@ -43,9 +43,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   ];
   // must be defined for modulizer
   var _boundScrollHandler;
-  if (!window.Polymer) {
-    window.Polymer = {};
-  }
 
   /**
    * The IronScrollManager is intended to provide a central source
@@ -68,6 +65,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     },
 
     /**
+     * The current element that defines the DOM boundaries of the
+     * scroll lock. This is always the most recently locking element.
+     * Required for modulizer
+     *
+     * @return {!Node|undefined}
+     */
+    getCurrentLockingElement: function() {
+      return this._lockingElements[this._lockingElements.length - 1];
+    },
+
+    /**
      * Returns true if the provided element is "scroll locked", which is to
      * say that it cannot be scrolled via pointer or keyboard interactions.
      *
@@ -76,10 +84,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      * not be scroll locked.
      */
     elementIsScrollLocked: function(element) {
-      var currentLockingElement = this.currentLockingElement;
+      var lockingElement = this.getCurrentLockingElement();
 
-      if (currentLockingElement === undefined)
+      if (lockingElement === undefined) {
         return false;
+      }
 
       var scrollLocked;
 
@@ -91,9 +100,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         return false;
       }
 
-      scrollLocked = !!currentLockingElement &&
-          currentLockingElement !== element &&
-          !this._composedTreeContains(currentLockingElement, element);
+      scrollLocked = !!lockingElement &&
+          lockingElement !== element &&
+          !this._composedTreeContains(lockingElement, element);
 
       if (scrollLocked) {
         this._lockedElementCache.push(element);
@@ -294,7 +303,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      */
     _getScrollableNodes: function(nodes) {
       var scrollables = [];
-      var lockingIndex = nodes.indexOf(this.currentLockingElement);
+      var lockingIndex = nodes.indexOf(this.getCurrentLockingElement());
       // Loop from root target to locking element (included).
       for (var i = 0; i <= lockingIndex; i++) {
         // Skip non-Element nodes.

--- a/iron-scroll-manager.html
+++ b/iron-scroll-manager.html
@@ -43,7 +43,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   ];
   // must be defined for modulizer
   var _boundScrollHandler;
-  var scope;
 
   /**
    * The IronScrollManager is intended to provide a central source
@@ -238,12 +237,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     _boundScrollHandler: undefined,
 
     _lockScrollInteractions: function() {
-      try {
-        this._boundScrollHandler = this._boundScrollHandler ||
-            this._scrollInteractionHandler.bind(scope);
-      } catch (e) {
-        this._boundScrollHandler =
-            this._boundScrollHandler || this._scrollInteractionHandler;
+      // workaround for modulizer not handling bind properly
+      if (!this._boundScrollHandler) {
+        try {
+          this._boundScrollHandler = this._scrollInteractionHandler.bind(this);
+        } catch (e) {
+          this._boundScrollHandler = this._scrollInteractionHandler;
+        }
       }
       for (var i = 0, l = scrollEvents.length; i < l; i++) {
         // NOTE: browsers that don't support objects as third arg will
@@ -406,7 +406,5 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       return info;
     }
   };
-
-  scope = Polymer.IronScrollManager;
   })();
 </script>

--- a/iron-scroll-manager.html
+++ b/iron-scroll-manager.html
@@ -43,6 +43,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   ];
   // must be defined for modulizer
   var _boundScrollHandler;
+  var currentLockingElement;
 
   /**
    * The IronScrollManager is intended to provide a central source
@@ -53,27 +54,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
    * @memberof Polymer
    */
   Polymer.IronScrollManager = {
-
     /**
      * The current element that defines the DOM boundaries of the
      * scroll lock. This is always the most recently locking element.
      *
      * @return {!Node|undefined}
      */
-    get currentLockingElement() {
-      return this._lockingElements[this._lockingElements.length - 1];
-    },
-
-    /**
-     * The current element that defines the DOM boundaries of the
-     * scroll lock. This is always the most recently locking element.
-     * Required for modulizer
-     *
-     * @return {!Node|undefined}
-     */
-    getCurrentLockingElement: function() {
-      return this._lockingElements[this._lockingElements.length - 1];
-    },
+    currentLockingElement: undefined,
 
     /**
      * Returns true if the provided element is "scroll locked", which is to
@@ -84,7 +71,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      * not be scroll locked.
      */
     elementIsScrollLocked: function(element) {
-      var lockingElement = this.getCurrentLockingElement();
+      var lockingElement = this.currentLockingElement;
 
       if (lockingElement === undefined) {
         return false;
@@ -134,6 +121,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
 
       this._lockingElements.push(element);
+      this.currentLockingElement = this._lockingElements[this._lockingElements.length - 1];
 
       this._lockedElementCache = [];
       this._unlockedElementCache = [];
@@ -157,6 +145,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
 
       this._lockingElements.splice(index, 1);
+      this.currentLockingElement = this._lockingElements[this._lockingElements.length - 1];
 
       this._lockedElementCache = [];
       this._unlockedElementCache = [];
@@ -308,7 +297,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      */
     _getScrollableNodes: function(nodes) {
       var scrollables = [];
-      var lockingIndex = nodes.indexOf(this.getCurrentLockingElement());
+      var lockingIndex = nodes.indexOf(this.currentLockingElement);
       // Loop from root target to locking element (included).
       for (var i = 0; i <= lockingIndex; i++) {
         // Skip non-Element nodes.

--- a/iron-scroll-manager.html
+++ b/iron-scroll-manager.html
@@ -43,6 +43,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   ];
   // must be defined for modulizer
   var _boundScrollHandler;
+  if (!Polymer) {
+    Polymer = {};
+  };
 
   /**
    * The IronScrollManager is intended to provide a central source
@@ -52,9 +55,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
    * @namespace
    * @memberof Polymer
    */
-  Polymer.IronScrollManager = {
-
-    /**
+  Polymer['IronScrollManager'] = {
+      /**
      * The current element that defines the DOM boundaries of the
      * scroll lock. This is always the most recently locking element.
      *
@@ -238,10 +240,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     _boundScrollHandler: undefined,
 
     _lockScrollInteractions: function() {
-      if (!Polymer) {
-        Polymer = {};
-      }
-
       this._boundScrollHandler =
           this._boundScrollHandler || this._scrollInteractionHandler.bind(this);
       for (var i = 0, l = scrollEvents.length; i < l; i++) {

--- a/iron-scroll-manager.html
+++ b/iron-scroll-manager.html
@@ -238,6 +238,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     _boundScrollHandler: undefined,
 
     _lockScrollInteractions: function() {
+      if (!Polymer) {
+        Polymer = {};
+      }
+
       this._boundScrollHandler =
           this._boundScrollHandler || this._scrollInteractionHandler.bind(this);
       for (var i = 0, l = scrollEvents.length; i < l; i++) {

--- a/iron-scroll-manager.html
+++ b/iron-scroll-manager.html
@@ -219,19 +219,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       return false;
     },
 
-    getScrollHandler: function(shouldPreventScrolling) {
-      return function(event) {
-        // Avoid canceling an event with cancelable=false, e.g. scrolling is in
-        // progress and cannot be interrupted.
-        if (event.cancelable && shouldPreventScrolling(event)) {
-          event.preventDefault();
-        }
-        // If event has targetTouches (touch event), update last touch position.
-        if (event.targetTouches) {
-          var touch = event.targetTouches[0];
-          lastTouchPosition.pageX = touch.pageX;
-          lastTouchPosition.pageY = touch.pageY;
-        }
+    _scrollInteractionHandler: function(event) {
+      // Avoid canceling an event with cancelable=false, e.g. scrolling is in
+      // progress and cannot be interrupted.
+      if (event.cancelable && this._shouldPreventScrolling(event)) {
+        event.preventDefault();
+      }
+      // If event has targetTouches (touch event), update last touch position.
+      if (event.targetTouches) {
+        var touch = event.targetTouches[0];
+        lastTouchPosition.pageX = touch.pageX;
+        lastTouchPosition.pageY = touch.pageY;
       }
     },
 
@@ -241,8 +239,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     _boundScrollHandler: undefined,
 
     _lockScrollInteractions: function() {
-      this._boundScrollHandler =
-          this._boundScrollHandler || this.getScrollHandler(this._shouldPreventScrolling);
+      try {
+        this._boundScrollHandler =
+            this._boundScrollHandler || this._scrollInteractionHandler.bind(scope);
+      } catch (e) {
+        this._boundScrollHandler =
+            this._boundScrollHandler || this._scrollInteractionHandler;
+      }
       for (var i = 0, l = scrollEvents.length; i < l; i++) {
         // NOTE: browsers that don't support objects as third arg will
         // interpret it as boolean, hence useCapture = true in this case.

--- a/test/iron-overlay-behavior.html
+++ b/test/iron-overlay-behavior.html
@@ -133,6 +133,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <input id="focusInput" placeholder="focus input">
 
   <script>
+    'use strict';
+
     function runAfterOpen(overlay, callback) {
       overlay.addEventListener('iron-overlay-opened', callback);
       overlay.open();
@@ -1006,7 +1008,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       test('backdrop appears behind the overlay', function(done) {
         runAfterOpen(overlay, function() {
-          styleZ = parseInt(window.getComputedStyle(overlay).zIndex, 10);
+          var styleZ = parseInt(window.getComputedStyle(overlay).zIndex, 10);
           backdropStyleZ =
               parseInt(window.getComputedStyle(overlay.backdropElement).zIndex, 10);
           assert.isTrue(

--- a/test/iron-overlay-behavior.html
+++ b/test/iron-overlay-behavior.html
@@ -1009,7 +1009,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       test('backdrop appears behind the overlay', function(done) {
         runAfterOpen(overlay, function() {
           var styleZ = parseInt(window.getComputedStyle(overlay).zIndex, 10);
-          backdropStyleZ =
+          var backdropStyleZ =
               parseInt(window.getComputedStyle(overlay.backdropElement).zIndex, 10);
           assert.isTrue(
               styleZ > backdropStyleZ, 'overlay has higher z-index than backdrop');


### PR DESCRIPTION
Ignore the million commits, I had to commit to run modulizer; I'm going to have to squash them.

## iron-scroll-manager.html
Added a declaration for `_boundScrollHandler` as modulizer does not play nice with namespaces and runs in strict mode.

Modulizer cannot work with getters in namespaces. It converts them to functions, so to keep backwards compatibility, I had to create a `getCurrentLockingElement ` function.

I had to wrap the `.bind(this)` in a try catch because modulizer would get rid of the `Polymer. IronScrollManager` namespace, but would replace the `this` in the `bind` with `Polymer. IronScrollManager` which would always fail. I could not get around this; it looks like modulizer would read the closure.

## test/iron-overlay-behavior.html
I added some `var`s for strict mode

## everything else
I added commas to the end of each property definition in the properties block so it looks nicer formatted with clang-format