### PR TITLE
Update `_focusableNodes` before every focus wrapping check.

### DIFF
--- a/iron-overlay-behavior.js
+++ b/iron-overlay-behavior.js
@@ -565,15 +565,13 @@ export const IronOverlayBehaviorImpl = {
   },
 
   /**
-   * Will set first and last focusable nodes if any of them is not set.
+   * Updates the references to the first and last focusable nodes.
    * @private
    */
   __ensureFirstLastFocusables: function() {
-    if (!this.__firstFocusableNode || !this.__lastFocusableNode) {
-      var focusableNodes = this._focusableNodes;
-      this.__firstFocusableNode = focusableNodes[0];
-      this.__lastFocusableNode = focusableNodes[focusableNodes.length - 1];
-    }
+    var focusableNodes = this._focusableNodes;
+    this.__firstFocusableNode = focusableNodes[0];
+    this.__lastFocusableNode = focusableNodes[focusableNodes.length - 1];
   },
 
   /**

--- a/test/iron-overlay-behavior.html
+++ b/test/iron-overlay-behavior.html
@@ -99,6 +99,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <template>
       <test-overlay with-backdrop>
         Overlay with backdrop
+        <input disabled>
+        <input>
+        <input disabled>
       </test-overlay>
     </template>
   </test-fixture>
@@ -873,6 +876,31 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             document.removeEventListener('keydown', tabSpy);
             done();
           }, 1);
+        });
+      });
+
+      const testName =
+          'with-backdrop: __firstFocusableNode and __lastFocusableNode are ' +
+          'updated after pressing tab.';
+      test(testName, function(done) {
+        const TAB = 9;
+        const overlay = fixture('backdrop');
+        const inputs = overlay.querySelectorAll('input');
+
+        runAfterOpen(overlay, function() {
+          MockInteractions.pressAndReleaseKeyOn(document, TAB);
+
+          assert.equal(overlay.__firstFocusableNode, inputs[1]);
+          assert.equal(overlay.__lastFocusableNode, inputs[1]);
+
+          inputs[0].removeAttribute('disabled');
+          inputs[2].removeAttribute('disabled');
+          MockInteractions.pressAndReleaseKeyOn(document, TAB);
+
+          assert.equal(overlay.__firstFocusableNode, inputs[0]);
+          assert.equal(overlay.__lastFocusableNode, inputs[2]);
+
+          done();
         });
       });
     });


### PR DESCRIPTION
cc @simonfuhrmann