### PR TITLE
Make IronFocusablesHelper a singleton

### DIFF
--- a/iron-focusables-helper.js
+++ b/iron-focusables-helper.js
@@ -16,7 +16,7 @@ var p = Element.prototype;
 var matches = p.matches || p.matchesSelector || p.mozMatchesSelector ||
     p.msMatchesSelector || p.oMatchesSelector || p.webkitMatchesSelector;
 
-export const IronFocusablesHelper = {
+class IronFocusablesHelperClass {
 
   /**
    * Returns a sorted array of tabbable nodes, including the root node.
@@ -25,7 +25,7 @@ export const IronFocusablesHelper = {
    * @param {!Node} node
    * @return {!Array<!HTMLElement>}
    */
-  getTabbableNodes: function(node) {
+  getTabbableNodes(node) {
     var result = [];
     // If there is at least one element with tabindex > 0, we need to sort
     // the final array by tabindex.
@@ -34,14 +34,14 @@ export const IronFocusablesHelper = {
       return this._sortByTabIndex(result);
     }
     return result;
-  },
+  }
 
   /**
    * Returns if a element is focusable.
    * @param {!HTMLElement} element
    * @return {boolean}
    */
-  isFocusable: function(element) {
+  isFocusable(element) {
     // From http://stackoverflow.com/a/1600194/4228703:
     // There isn't a definite list, it's up to the browser. The only
     // standard we have is DOM Level 2 HTML
@@ -59,7 +59,7 @@ export const IronFocusablesHelper = {
     // Elements that can be focused even if they have [disabled] attribute.
     return matches.call(
         element, 'a[href], area[href], iframe, [tabindex], [contentEditable]');
-  },
+  }
 
   /**
    * Returns if a element is tabbable. To be tabbable, a element must be
@@ -67,11 +67,11 @@ export const IronFocusablesHelper = {
    * @param {!HTMLElement} element
    * @return {boolean}
    */
-  isTabbable: function(element) {
+  isTabbable(element) {
     return this.isFocusable(element) &&
         matches.call(element, ':not([tabindex="-1"])') &&
         this._isVisible(element);
-  },
+  }
 
   /**
    * Returns the normalized element tabindex. If not focusable, returns -1.
@@ -82,13 +82,13 @@ export const IronFocusablesHelper = {
    * @return {!number}
    * @private
    */
-  _normalizedTabIndex: function(element) {
+  _normalizedTabIndex(element) {
     if (this.isFocusable(element)) {
       var tabIndex = element.getAttribute('tabindex') || 0;
       return Number(tabIndex);
     }
     return -1;
-  },
+  }
 
   /**
    * Searches for nodes that are tabbable and adds them to the `result` array.
@@ -99,7 +99,7 @@ export const IronFocusablesHelper = {
    * @return {boolean}
    * @private
    */
-  _collectTabbableNodes: function(node, result) {
+  _collectTabbableNodes(node, result) {
     // If not an element or not visible, no need to explore children.
     if (node.nodeType !== Node.ELEMENT_NODE || !this._isVisible(node)) {
       return false;
@@ -110,7 +110,6 @@ export const IronFocusablesHelper = {
     if (tabIndex >= 0) {
       result.push(element);
     }
-
     // In ShadowDOM v1, tab order is affected by the order of distrubution.
     // E.g. getTabbableNodes(#root) in ShadowDOM v1 should return [#A, #B];
     // in ShadowDOM v0 tab order is not affected by the distrubution order,
@@ -136,7 +135,7 @@ export const IronFocusablesHelper = {
       needsSort = this._collectTabbableNodes(children[i], result) || needsSort;
     }
     return needsSort;
-  },
+  }
 
   /**
    * Returns false if the element has `visibility: hidden` or `display: none`
@@ -144,7 +143,7 @@ export const IronFocusablesHelper = {
    * @return {boolean}
    * @private
    */
-  _isVisible: function(element) {
+  _isVisible(element) {
     // Check inline style first to save a re-flow. If looks good, check also
     // computed style.
     var style = element.style;
@@ -153,7 +152,7 @@ export const IronFocusablesHelper = {
       return (style.visibility !== 'hidden' && style.display !== 'none');
     }
     return false;
-  },
+  }
 
   /**
    * Sorts an array of tabbable elements by tabindex. Returns a new array.
@@ -161,7 +160,7 @@ export const IronFocusablesHelper = {
    * @return {!Array<!HTMLElement>}
    * @private
    */
-  _sortByTabIndex: function(tabbables) {
+  _sortByTabIndex(tabbables) {
     // Implement a merge sort as Array.prototype.sort does a non-stable sort
     // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort
     var len = tabbables.length;
@@ -172,7 +171,7 @@ export const IronFocusablesHelper = {
     var left = this._sortByTabIndex(tabbables.slice(0, pivot));
     var right = this._sortByTabIndex(tabbables.slice(pivot));
     return this._mergeSortByTabIndex(left, right);
-  },
+  }
 
   /**
    * Merge sort iterator, merges the two arrays into one, sorted by tab index.
@@ -181,7 +180,7 @@ export const IronFocusablesHelper = {
    * @return {!Array<!HTMLElement>}
    * @private
    */
-  _mergeSortByTabIndex: function(left, right) {
+  _mergeSortByTabIndex(left, right) {
     var result = [];
     while ((left.length > 0) && (right.length > 0)) {
       if (this._hasLowerTabOrder(left[0], right[0])) {
@@ -192,7 +191,7 @@ export const IronFocusablesHelper = {
     }
 
     return result.concat(left, right);
-  },
+  }
 
   /**
    * Returns if element `a` has lower tab order compared to element `b`
@@ -205,11 +204,13 @@ export const IronFocusablesHelper = {
    * @return {boolean}
    * @private
    */
-  _hasLowerTabOrder: function(a, b) {
+  _hasLowerTabOrder(a, b) {
     // Normalize tabIndexes
     // e.g. in Firefox `<div contenteditable>` has `tabIndex = -1`
     var ati = Math.max(a.tabIndex, 0);
     var bti = Math.max(b.tabIndex, 0);
     return (ati === 0 || bti === 0) ? bti > ati : ati > bti;
   }
-};
+}
+
+export const IronFocusablesHelper = new IronFocusablesHelperClass();

--- a/iron-focusables-helper.js
+++ b/iron-focusables-helper.js
@@ -17,7 +17,6 @@ var matches = p.matches || p.matchesSelector || p.mozMatchesSelector ||
     p.msMatchesSelector || p.oMatchesSelector || p.webkitMatchesSelector;
 
 class IronFocusablesHelperClass {
-
   /**
    * Returns a sorted array of tabbable nodes, including the root node.
    * It searches the tabbable nodes in the light and shadow dom of the chidren,


### PR DESCRIPTION
This is easier for closure compiler to read and optimize correctly, and is otherwise a no-op.

Similar to the change we made to the other helper in this repo.

Internalized as cl/218204453