### PR TITLE
Check for scroll or auto anywhere in node style

### DIFF
--- a/iron-scroll-manager.js
+++ b/iron-scroll-manager.js
@@ -289,10 +289,10 @@ export function _getScrollableNodes(nodes) {
     var node = /** @type {!Element} */ (nodes[i]);
     // Check inline style before checking computed style.
     var style = node.style;
-    if (style.overflow !== 'scroll' && style.overflow !== 'auto') {
+    if (style.overflow.includes('scroll') && style.overflow.includes('auto')) {
       style = window.getComputedStyle(node);
     }
-    if (style.overflow === 'scroll' || style.overflow === 'auto') {
+    if (style.overflow.includes('scroll') || style.overflow.includes('auto')) {
       scrollables.push(node);
     }
   }


### PR DESCRIPTION
A valid computed style for overflow is "scroll auto". The existing implementation would consider this style a "non-scrollable" node. This change handles the edge case.