### PR TITLE
Update deprecated function call

### DIFF
--- a/iron-overlay-manager.js
+++ b/iron-overlay-manager.js
@@ -46,7 +46,7 @@ export class IronOverlayManagerClass {
     // NOTE: enable tap on <html> to workaround Polymer/polymer#4459
     // Pass no-op function because MSEdge 15 doesn't handle null as 2nd argument
     // https://github.com/Microsoft/ChakraCore/issues/3863
-    gestures.add(document.documentElement, 'tap', function() {});
+    gestures.addListener(document.documentElement, 'tap', function() {});
     document.addEventListener('tap', this._onCaptureClick.bind(this), true);
     document.addEventListener('focus', this._onCaptureFocus.bind(this), true);
     document.addEventListener(


### PR DESCRIPTION
Replace call to deprecated Polymer.Gestures.add function with Polymer.Gestures.addListener.

Fixes a Closure compiler error (JSC_DEPRECATED_PROP_REASON).