### PR TITLE
Restore focus if the node with focus in the overlay is distributed into it.

### DIFF
--- a/iron-overlay-behavior.js
+++ b/iron-overlay-behavior.js
@@ -763,7 +763,8 @@ export const IronOverlayBehaviorImpl = {
 
 };
 
-const composedParent = node => node.assignedSlot || node.parentNode || node.host;
+const composedParent = node =>
+    node.assignedSlot || node.parentNode || node.host;
 
 const composedContains = (ancestor, descendant) => {
   for (let element = descendant; element; element = composedParent(element)) {

--- a/iron-overlay-behavior.js
+++ b/iron-overlay-behavior.js
@@ -440,7 +440,7 @@ export const IronOverlayBehaviorImpl = {
         // button outside the overlay).
         var activeElement = this._manager.deepActiveElement;
         if (activeElement === document.body ||
-            dom(this).deepContains(activeElement)) {
+            composedContains(this, activeElement)) {
           this.__restoreFocusNode.focus();
         }
       }
@@ -750,6 +750,17 @@ export const IronOverlayBehaviorImpl = {
     }
   },
 
+};
+
+const composedParent = node => node.assignedSlot || node.parentNode || node.host;
+
+const composedContains = (ancestor, descendant) => {
+  for (let element = descendant; element; element = composedParent(element)) {
+    if (element === ancestor) {
+      return true;
+    }
+  }
+  return false;
 };
 
 /**

--- a/test/has-shadow-overlay.js
+++ b/test/has-shadow-overlay.js
@@ -1,0 +1,55 @@
+/**
+@license
+Copyright (c) 2019 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at
+http://polymer.github.io/LICENSE.txt The complete set of authors may be found at
+http://polymer.github.io/AUTHORS.txt The complete set of contributors may be
+found at http://polymer.github.io/CONTRIBUTORS.txt Code distributed by Google as
+part of the polymer project is also subject to an additional IP rights grant
+found at http://polymer.github.io/PATENTS.txt
+*/
+import '@polymer/polymer/polymer-legacy.js';
+
+import {Polymer} from '@polymer/polymer/lib/legacy/polymer-fn.js';
+import {dom} from '@polymer/polymer/lib/legacy/polymer.dom.js';
+import {html} from '@polymer/polymer/lib/utils/html-tag.js';
+
+import {IronOverlayBehavior} from '../iron-overlay-behavior.js';
+
+const trivialOverlayLocalName =
+    `trivial-overlay-${Math.random().toString(32).substring(2)}`;
+
+Polymer({
+  _template: html`
+    <style>
+      :host {
+        background: white;
+        color: black;
+        border: 1px solid black;
+      }
+    </style>
+
+    <slot></slot>
+  `,
+
+  is: trivialOverlayLocalName,
+  behaviors: [IronOverlayBehavior],
+});
+
+Polymer({
+  _template: html``,
+
+  is: 'has-shadow-overlay',
+
+  attached() {
+    // Set up the shadow root:
+    // ```html
+    // <trivialOverlayLocalName>
+    //   <slot></slot>
+    // </trivialOverlayLocalName>
+    // ```
+    this.overlay = document.createElement(trivialOverlayLocalName);
+    dom(this.overlay).appendChild(document.createElement('slot'));
+    dom(this.root).appendChild(this.overlay);
+  },
+});

--- a/test/iron-overlay-behavior.html
+++ b/test/iron-overlay-behavior.html
@@ -993,7 +993,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
       });
 
-      test.only(
+      test(
           'overlay returns focus on close (distributed focusable content)',
           function(done) {
             var hasShadowOverlay = fixture('has-shadow-overlay');

--- a/test/iron-overlay-behavior.html
+++ b/test/iron-overlay-behavior.html
@@ -127,6 +127,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </template>
   </test-fixture>
 
+  <test-fixture id="has-shadow-overlay">
+    <template>
+      <has-shadow-overlay>
+        <button>button</button>
+      </has-shadow-overlay>
+    </template>
+  </test-fixture>
+
   <test-buttons id="buttons"></test-buttons>
   <input id="focusInput" placeholder="focus input">
 
@@ -136,6 +144,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     import './test-overlay2.js';
     import './test-buttons.js';
     import './test-menu-button.js';
+    import './has-shadow-overlay.js';
 
     import {dom, flush} from '@polymer/polymer/lib/legacy/polymer.dom.js';
     import {afterNextRender} from '@polymer/polymer/lib/utils/render-status.js';
@@ -979,6 +988,37 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
                 IronOverlayManager.deepActiveElement,
                 focusable,
                 'focus restored to focusable');
+            done();
+          });
+        });
+      });
+
+      test.only('overlay returns focus on close (distributed focusable ' +
+          'content)', function(done) {
+        var hasShadowOverlay = fixture('has-shadow-overlay');
+        hasShadowOverlay.overlay.restoreFocusOnClose = true;
+
+        var button = dom(hasShadowOverlay).querySelector('button');
+
+        var focusable = document.getElementById('focusInput');
+        focusable.focus();
+
+        runAfterOpen(hasShadowOverlay.overlay, async function() {
+          button.focus();
+          assert.equal(
+              IronOverlayManager.deepActiveElement,
+              button,
+              'the distributed content is focused');
+
+          runAfterClose(hasShadowOverlay.overlay, async function() {
+            // Focus should be restored to the input even though the focused
+            // button inside the overlay was not a shadow-including descendant
+            // of the overlay.
+            assert.equal(
+                IronOverlayManager.deepActiveElement,
+                focusable,
+                'focus restored to focusable');
+
             done();
           });
         });

--- a/test/iron-overlay-behavior.html
+++ b/test/iron-overlay-behavior.html
@@ -993,36 +993,37 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
       });
 
-      test.only('overlay returns focus on close (distributed focusable ' +
-          'content)', function(done) {
-        var hasShadowOverlay = fixture('has-shadow-overlay');
-        hasShadowOverlay.overlay.restoreFocusOnClose = true;
+      test.only(
+          'overlay returns focus on close (distributed focusable content)',
+          function(done) {
+            var hasShadowOverlay = fixture('has-shadow-overlay');
+            hasShadowOverlay.overlay.restoreFocusOnClose = true;
 
-        var button = dom(hasShadowOverlay).querySelector('button');
+            var button = dom(hasShadowOverlay).querySelector('button');
 
-        var focusable = document.getElementById('focusInput');
-        focusable.focus();
+            var focusable = document.getElementById('focusInput');
+            focusable.focus();
 
-        runAfterOpen(hasShadowOverlay.overlay, async function() {
-          button.focus();
-          assert.equal(
-              IronOverlayManager.deepActiveElement,
-              button,
-              'the distributed content is focused');
+            runAfterOpen(hasShadowOverlay.overlay, async function() {
+              button.focus();
+              assert.equal(
+                  IronOverlayManager.deepActiveElement,
+                  button,
+                  'the distributed content is focused');
 
-          runAfterClose(hasShadowOverlay.overlay, async function() {
-            // Focus should be restored to the input even though the focused
-            // button inside the overlay was not a shadow-including descendant
-            // of the overlay.
-            assert.equal(
-                IronOverlayManager.deepActiveElement,
-                focusable,
-                'focus restored to focusable');
+              runAfterClose(hasShadowOverlay.overlay, async function() {
+                // Focus should be restored to the input even though the
+                // focused button inside the overlay was not a shadow-including
+                // descendant of the overlay.
+                assert.equal(
+                    IronOverlayManager.deepActiveElement,
+                    focusable,
+                    'focus restored to focusable');
 
-            done();
+                done();
+              });
+            });
           });
-        });
-      });
 
       test('avoids restoring focus if focus changed', function(done) {
         var button0 = document.getElementById('buttons').$.button0;


### PR DESCRIPTION
Before this PR, focus was only restored when closing an overlay if there was no focused element (or `<body>`) or the focused element was a shadow-including descendant of the overlay. This prevented focus from being restored if the focused element inside the overlay was distributed into the overlay through a slot:

```html
<outer-element>
  #shadow-root
    <element-with-iron-overlay-behavior>
      <slot name="in-overlay">
    </element-with-iron-overlay-behavior>
  #/shadow-root
  <input slot="in-overlay">
</outer-element>
```

This PR changes the test to check that the focused node is any descendant of the overlay in the *flattened* tree.